### PR TITLE
Update to enable wrap of json data that contains the delimiter value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ var converter = require('json-2-csv');
   * `DELIMITER` - Document - Specifies the different types of delimiters
     * `FIELD` - String - Field Delimiter. Default: `','`
     * `ARRAY` - String - Array Value Delimiter. Default: `';'`
+    * `WRAP` - String - A character to wrap each value in for data that contains the field delimiter (e.g. `'\"'`). Default: `null`
   * `EOL` - String - End of Line Delimiter. Default: `'\n'`
   * `PARSE_CSV_NUMBERS` - Boolean - Should numbers that are found in the CSV be converted to numbers? Default: `false`
 

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -8,7 +8,8 @@ var json2Csv = require('./json-2-csv'), // Require our json-2-csv code
 var defaultOptions = {
     DELIMITER         : {
         FIELD  :  ',',
-        ARRAY  :  ';'
+        ARRAY  :  ';',
+        WRAP   :  ''
     },
     EOL               : '\n',
     PARSE_CSV_NUMBERS : false

--- a/lib/json-2-csv.js
+++ b/lib/json-2-csv.js
@@ -15,7 +15,7 @@ var retrieveSubHeading = function (heading, data) {
         if (typeof data[subKey] === 'object' && data[subKey] !== null && typeof data[subKey].length === 'undefined') { // If we have another nested document
             subKeys[indx] = retrieveSubHeading(newKey, data[subKey]); // Recur on the subdocument to retrieve the full key name
         } else {
-            subKeys[indx] = newKey; // Set the key name since we don't have a sub document
+            subKeys[indx] = options.DELIMITER.WRAP + newKey + options.DELIMITER.WRAP; // Set the key name since we don't have a sub document
         }
     });
     return subKeys.join(options.DELIMITER.FIELD); // Return the headings joined by our field delimiter
@@ -49,9 +49,9 @@ var convertData = function (data, keys) {
             if (typeof value === 'object' && value !== null && typeof value.length === 'undefined') { // If we have an object
                 output.push(convertData(value, _.keys(value))); // Push the recursively generated CSV
             } else if (typeof value === 'object' && value !== null && typeof value.length === 'number') { // We have an array of values
-                output.push('[' + value.join(options.DELIMITER.ARRAY) + ']');
+                output.push(options.DELIMITER.WRAP + '[' + value.join(options.DELIMITER.ARRAY) + ']' + options.DELIMITER.WRAP);
             } else {
-                output.push(value); // Otherwise push the current value
+                output.push(options.DELIMITER.WRAP + value + options.DELIMITER.WRAP); // Otherwise push the current value
             }
         }
     });


### PR DESCRIPTION
I found an issue when I was using this function to convert some json data that had commas in the values. Not wanting to move away from using CSV, I added a few string appends and an additional option to specify a character to wrap each field in.
