### PR TITLE
Fixing issue where field ordering caused schema error

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ _Note_: This requires `mocha`, `should`, `async`, and `underscore`.
 ## Features
 
 - Header Generation (per document keys)
-- Verifies all documents have same schema
+- Verifies all documents have same schema (schema field order does not matter as of 1.1.0)
 - Supports sub-documents natively
 - Supports arrays as document values for both json2csv and csv2json
 - Custom ordering of columns (see F.A.Q. for more information)
@@ -152,8 +152,3 @@ __Yes.__ Currently, changing the order of the keys in the JSON document will als
 ## Milestones
  - Created: Apr 23, 2014
  - 1K Downloads/Month: January 15, 2015
-
-## TODO
-- Use PARSE_CSV_NUMBERS option to actually convert numbers. Not currently implemented.
-- Respect nested arrays when in json2csv - Currently flattens them
-- If quotes in CSV header, strip them? Add as an option?

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "json-2-csv",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "homepage": "https://github.com/mrodrig/json-2-csv",
   "moduleType": [
     "node"
@@ -15,6 +15,6 @@
   ],
   "dependencies": {
     "underscore": "1.6.0",
-    "async": "0.2.10"
+    "bluebird": "2.9.24"
   }
 }

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -4,7 +4,9 @@ var json2Csv = require('./json-2-csv'), // Require our json-2-csv code
     csv2Json = require('./csv-2-json'), // Require our csv-2-json code
     _ = require('underscore'); // Require underscore
 
-// Default options; By using a function this is essentially a 'static' variable
+/**
+ * Default options
+ */
 var defaultOptions = {
     DELIMITER         : {
         FIELD  :  ',',
@@ -15,16 +17,19 @@ var defaultOptions = {
     PARSE_CSV_NUMBERS : false
 };
 
-// Build the options to be passed to the appropriate function
-// If a user does not provide custom options, then we use our default
-// If options are provided, then we set each valid key that was passed
+/**
+ * Build the options to be passed to the appropriate function
+ * If a user does not provide custom options, then we use our default
+ * If options are provided, then we set each valid key that was passed
+ */
 var buildOptions = function (opts, cb) {
-    opts = opts ? opts : {}; // If undefined, set to an empty doc
-    var out = _.defaults(opts, defaultOptions);
+    opts = _.defaults(opts || {}, defaultOptions);
+    // Note: _.defaults does a shallow default, we need to deep copy the DELIMITER object
+    opts.DELIMITER = _.defaults(opts.DELIMITER || {}, defaultOptions.DELIMITER);
     // If the delimiter fields are the same, report an error to the caller
-    if (out.DELIMITER.FIELD === out.DELIMITER.ARRAY) { return cb(new Error('The field and array delimiters must differ.')); }
+    if (opts.DELIMITER.FIELD === opts.DELIMITER.ARRAY) { return cb(new Error('The field and array delimiters must differ.')); }
     // Otherwise, send the options back
-    else { return cb(null, out); }
+    else { return cb(null, opts); }
 };
 
 // Export the following functions that will be client accessible

--- a/lib/csv-2-json.js
+++ b/lib/csv-2-json.js
@@ -34,7 +34,7 @@ var addNestedKey = function (key, value, doc) {
 
 // Helper function to check if the given key already exists in the given document
 var keyExists = function (key, doc) {
-    return (typeof doc[key] !== 'undefined'); // If the key doesn't exist, then the type is 'undefined'
+    return (!_.isUndefined(doc[key])); // If the key doesn't exist, then the type is 'undefined'
 };
 
 var isArrayRepresentation = function (value) {
@@ -96,7 +96,7 @@ module.exports = {
         if (!opts) { callback(new Error('Options were not passed and are required.')); return null; } // Shouldn't happen, but just in case
         else { options = opts; } // Options were passed, set the global options value
         if (!data) { callback(new Error('Cannot call csv2json on ' + data + '.')); return null; } // If we don't receive data, report an error
-        if (typeof data !== 'string') { // The data is not a string
+        if (!_.isString(data)) { // The data is not a string
             callback(new Error("CSV is not a string.")); // Report an error back to the caller
         }
         var lines = data.split(options.EOL); // Split the CSV into lines using the specified EOL option

--- a/lib/csv-2-json.js
+++ b/lib/csv-2-json.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var _ = require('underscore'),
-    async = require('async');
+var _ = require('underscore');
 
 var options = {}; // Initialize the options - this will be populated when the csv2json function is called.
 

--- a/lib/json-2-csv.js
+++ b/lib/json-2-csv.js
@@ -3,38 +3,49 @@
 var _ = require('underscore'),
     async = require('async');
 
-var options = {}; // Initialize the options - this will be populated when the csv2json function is called.
+var options = {}; // Initialize the options - this will be populated when the json2csv function is called.
+
+// Retrieve the headings for all documents and return it.  This checks that all documents have the same schema.
+var generateHeading = function(data, cb) {
+    var keys = _.map(_.keys(data), function (key, indx) { // for each key
+        if (_.isObject(data[key])) {
+            // if the data at the key is a document, then we retrieve the subHeading starting with an empty string heading and the doc
+            return generateSubHeading('', data[key]);
+        }
+        return key;
+    });
+
+    // TODO: check for consistent schema
+
+    keys = _.map(keys, function(keyList) {
+        return _.flatten(keyList).join(options.DELIMITER.FIELD);
+    });
+
+    // Retrieve the unique array of headings (keys)
+    keys = _.uniq(keys);
+
+    // If we have more than 1 unique list, then not all docs have the same schema - report an error
+    if (keys.length > 1) { throw new Error('Not all documents have the same schema.', keys); }
+
+    return cb(null, keys);
+};
 
 // Takes the parent heading and this doc's data and creates the subdocument headings (string)
-var retrieveSubHeading = function (heading, data) {
-    var subKeys = _.keys(data), // retrieve the keys from the current document
-        newKey; // temporary variable to aid in determining the heading - used to generate the 'nested' headings
-    _.each(subKeys, function (subKey, indx) {
+var generateSubHeading = function(heading, data) {
+    var subKeys, // retrieve the keys from the current document
+        newKey = ''; // temporary variable to aid in determining the heading - used to generate the 'nested' headings
+
+    subKeys = _.map(_.keys(data), function (subKey) {
         // If the given heading is empty, then we set the heading to be the subKey, otherwise set it as a nested heading w/ a dot
         newKey = heading === '' ? subKey : heading + '.' + subKey;
         if (_.isObject(data[subKey]) && !_.isNull(data[subKey]) && _.isUndefined(data[subKey].length) && _.keys(data[subKey]).length > 0) { // If we have another nested document
-            subKeys[indx] = retrieveSubHeading(newKey, data[subKey]); // Recur on the subdocument to retrieve the full key name
+            return generateSubHeading(newKey, data[subKey]); // Recur on the sub-document to retrieve the full key name
         } else {
-            subKeys[indx] = (options.DELIMITER.WRAP || '') + (newKey || '') + (options.DELIMITER.WRAP || ''); // Set the key name since we don't have a sub document
+            return options.DELIMITER.WRAP + newKey + options.DELIMITER.WRAP; // Set the key name since we don't have a sub document
         }
     });
-    return subKeys.join(options.DELIMITER.FIELD); // Return the headings joined by our field delimiter
-};
 
-// Retrieve the headings for all documents and return it.  This checks that all documents have the same schema.
-var retrieveHeading = function (data, cb) {
-    var keys = _.keys(data); // Retrieve the current data keys
-    _.each(keys, function (key, indx) { // for each key
-        if (_.isObject(data[key])) {
-            // if the data at the key is a document, then we retrieve the subHeading starting with an empty string heading and the doc
-            keys[indx] = retrieveSubHeading('', data[key]);
-        }
-    });
-    // Retrieve the unique array of headings (keys)
-    keys = _.uniq(keys);
-    // If we have more than 1 unique list, then not all docs have the same schema - report an error
-    if (keys.length > 1) { throw new Error('Not all documents have the same schema.', keys); }
-    return cb(null, _.flatten(keys).join(options.DELIMITER.FIELD)); // Return headings back
+    return subKeys; // Return the headings joined by our field delimiter
 };
 
 // Convert the given data with the given keys
@@ -71,17 +82,17 @@ module.exports = {
     // Takes options as a document, data as a JSON document array, and a callback that will be used to report the results
     json2csv: function (opts, data, callback) {
         if (!callback) { throw new Error('A callback is required!'); } // If a callback wasn't provided, throw an error
-        if (!opts) { callback(new Error('Options were not passed and are required.')); return null; } // Shouldn't happen, but just in case
+        if (!opts) { return callback(new Error('Options were not passed and are required.')); } // Shouldn't happen, but just in case
         else { options = opts; } // Options were passed, set the global options value
-        if (!data) { callback(new Error('Cannot call json2csv on ' + data + '.')); return null; } // If we don't receive data, report an error
+        if (!data) { return callback(new Error('Cannot call json2csv on ' + data + '.')); } // If we don't receive data, report an error
         if (!_.isObject(data)) { // If the data was not a single document or an array of documents
-            return cb(new Error('Data provided was not an array of documents.'));  // Report the error back to the caller
+            return callback(new Error('Data provided was not an array of documents.'));  // Report the error back to the caller
         } else if (_.isObject(data) && !data.length) { // Single document, not an array
             data = [data]; // Convert to an array of the given document
         }
 
         // Retrieve the heading and the CSV asynchronously in parallel
-        async.parallel([_.partial(retrieveHeading, data), _.partial(generateCsv, data)], function (err, res) {
+        async.parallel([_.partial(generateHeading, data), _.partial(generateCsv, data)], function (err, res) {
             if (!err) {
                 // Data received with no errors, join the two responses with an end of line delimiter to setup heading and CSV body
                 return callback(null, res.join(options.EOL));

--- a/lib/json-2-csv.js
+++ b/lib/json-2-csv.js
@@ -1,33 +1,37 @@
 'use strict';
 
 var _ = require('underscore'),
-    async = require('async');
+    Promise = require('bluebird');
 
 var options = {}; // Initialize the options - this will be populated when the json2csv function is called.
 
 // Retrieve the headings for all documents and return it.  This checks that all documents have the same schema.
-var generateHeading = function(data, cb) {
-    var keys = _.map(_.keys(data), function (key, indx) { // for each key
-        if (_.isObject(data[key])) {
-            // if the data at the key is a document, then we retrieve the subHeading starting with an empty string heading and the doc
-            return generateSubHeading('', data[key]);
+var generateHeading = function(data) {
+    return new Promise(function (resolve, reject) {
+        var keys = _.map(_.keys(data), function (key, indx) { // for each key
+            if (_.isObject(data[key])) {
+                // if the data at the key is a document, then we retrieve the subHeading starting with an empty string heading and the doc
+                return generateSubHeading('', data[key]);
+            }
+            return key;
+        });
+
+        // Check for a consistent schema that does not require the same order:
+        // if we only have one document - then there is no possiblility of multiple schemas
+        if (keys && keys.length <= 1) {
+            return resolve(_.flatten(keys) || []);
         }
-        return key;
+        // else - multiple documents - ensure only one schema (regardless of field ordering)
+        var firstDocSchema = _.flatten(keys[0]);
+        _.each(keys, function (keyList) {
+            // If there is a difference between the schemas, throw the inconsistent schema error
+            var diff = _.difference(firstDocSchema, _.flatten(keyList));
+            if (!_.isEqual(diff, [])) {
+                return reject(new Error('Not all documents have the same schema.'));
+            }
+        });
+        return resolve(_.flatten(keys[0]));
     });
-
-    // TODO: check for consistent schema
-
-    keys = _.map(keys, function(keyList) {
-        return _.flatten(keyList).join(options.DELIMITER.FIELD);
-    });
-
-    // Retrieve the unique array of headings (keys)
-    keys = _.uniq(keys);
-
-    // If we have more than 1 unique list, then not all docs have the same schema - report an error
-    if (keys.length > 1) { throw new Error('Not all documents have the same schema.', keys); }
-
-    return cb(null, keys);
 };
 
 // Takes the parent heading and this doc's data and creates the subdocument headings (string)
@@ -41,7 +45,7 @@ var generateSubHeading = function(heading, data) {
         if (_.isObject(data[subKey]) && !_.isNull(data[subKey]) && _.isUndefined(data[subKey].length) && _.keys(data[subKey]).length > 0) { // If we have another nested document
             return generateSubHeading(newKey, data[subKey]); // Recur on the sub-document to retrieve the full key name
         } else {
-            return options.DELIMITER.WRAP + newKey + options.DELIMITER.WRAP; // Set the key name since we don't have a sub document
+            return newKey; // Set the key name since we don't have a sub document
         }
     });
 
@@ -52,28 +56,40 @@ var generateSubHeading = function(heading, data) {
 var convertData = function (data, keys) {
     var output = [], // Array of CSV representing converted docs
         value; // Temporary variable to store the current data
-    _.each(keys, function (key, indx) { // For each key
-        value = data[key]; // Set the current data that we are looking at
-        if (keys.indexOf(key) > -1) { // If the keys contain the current key, then process the data
-            if (_.isArray(value)) { // We have an array of values
-                output.push((options.DELIMITER.WRAP || '') + '[' + value.join(options.DELIMITER.ARRAY) + ']' + (options.DELIMITER.WRAP || ''));
-            } else if (_.isDate(value)) { // If we have a date
-                output.push(value.toString());
-            } else if (_.isObject(value)) { // If we have an object
-                output.push(convertData(value, _.keys(value))); // Push the recursively generated CSV
-            } else {
-                value = value == null ? '' : value.toString();
-                output.push((options.DELIMITER.WRAP || '') + value + (options.DELIMITER.WRAP || '')); // Otherwise push the current value
-            }
+
+    _.each(keys, function (key) { // For each key
+        var indexOfPeriod = _.indexOf(key, '.');
+        if (indexOfPeriod > -1) {
+            var pathPrefix = key.slice(0, indexOfPeriod),
+                pathRemainder = key.slice(indexOfPeriod+1);
+            output.push(convertData(data[pathPrefix], [pathRemainder]));
+        } else if (keys.indexOf(key) > -1) { // If the keys contain the current key, then process the data
+            value = data[key]; // Set the current data that we are looking at
+            convertField(value, output);
         }
     });
-    return output.join(options.DELIMITER.FIELD); // Return the data joined by our field delimiter
+    return output; // Return the data joined by our field delimiter
+};
+
+var convertField = function (value, output) {
+    if (_.isArray(value)) { // We have an array of values
+        output.push(options.DELIMITER.WRAP + '[' + value.join(options.DELIMITER.ARRAY) + ']' + options.DELIMITER.WRAP);
+    } else if (_.isDate(value)) { // If we have a date
+        output.push(value.toString());
+    } else if (_.isObject(value)) { // If we have an object
+        output.push(convertData(value, _.keys(value))); // Push the recursively generated CSV
+    } else {
+        value = value === null ? '' : value.toString();
+        output.push(options.DELIMITER.WRAP + value + options.DELIMITER.WRAP); // Otherwise push the current value
+    }
 };
 
 // Generate the CSV representing the given data.
-var generateCsv = function (data, cb) {
+var generateCsv = function (data, headingKeys) {
     // Reduce each JSON document in data to a CSV string and append it to the CSV accumulator
-    return cb(null, _.reduce(data, function (csv, doc) { return csv += convertData(doc, _.keys(doc)) + options.EOL; }, ''));
+    return Promise.resolve([headingKeys, _.reduce(data, function (csv, doc) {
+        return csv += _.flatten(convertData(doc, headingKeys)).join(options.DELIMITER.FIELD) + options.EOL;
+    }, '')]);
 };
 
 module.exports = {
@@ -82,24 +98,33 @@ module.exports = {
     // Takes options as a document, data as a JSON document array, and a callback that will be used to report the results
     json2csv: function (opts, data, callback) {
         if (!callback) { throw new Error('A callback is required!'); } // If a callback wasn't provided, throw an error
+
         if (!opts) { return callback(new Error('Options were not passed and are required.')); } // Shouldn't happen, but just in case
         else { options = opts; } // Options were passed, set the global options value
+
         if (!data) { return callback(new Error('Cannot call json2csv on ' + data + '.')); } // If we don't receive data, report an error
+
         if (!_.isObject(data)) { // If the data was not a single document or an array of documents
             return callback(new Error('Data provided was not an array of documents.'));  // Report the error back to the caller
         } else if (_.isObject(data) && !data.length) { // Single document, not an array
             data = [data]; // Convert to an array of the given document
         }
 
-        // Retrieve the heading and the CSV asynchronously in parallel
-        async.parallel([_.partial(generateHeading, data), _.partial(generateCsv, data)], function (err, res) {
-            if (!err) {
-                // Data received with no errors, join the two responses with an end of line delimiter to setup heading and CSV body
-                return callback(null, res.join(options.EOL));
-            } else {
-                return callback(err, null); // Report received error back to caller
-            }
-        });
+        // Retrieve the heading and then generate the CSV with the keys that are identified
+        generateHeading(data)
+            .then(_.partial(generateCsv, data))
+            .spread(function (csvHeading, csvData) {
+                if (options.DELIMITER.WRAP) {
+                    csvHeading = _.map(csvHeading, function(headingKey) {
+                        return options.DELIMITER.WRAP + headingKey + options.DELIMITER.WRAP;
+                    });
+                }
+                csvHeading = csvHeading.join(options.DELIMITER.FIELD);
+                return callback(null, [csvHeading, csvData].join(options.EOL));
+            })
+            .catch(function (err) {
+                return callback(err);
+            });
     }
 
 };

--- a/lib/json-2-csv.js
+++ b/lib/json-2-csv.js
@@ -12,7 +12,7 @@ var retrieveSubHeading = function (heading, data) {
     _.each(subKeys, function (subKey, indx) {
         // If the given heading is empty, then we set the heading to be the subKey, otherwise set it as a nested heading w/ a dot
         newKey = heading === '' ? subKey : heading + '.' + subKey;
-        if (typeof data[subKey] === 'object' && data[subKey] !== null && typeof data[subKey].length === 'undefined' && _.keys(data[subKey]).length > 0) { // If we have another nested document
+        if (_.isObject(data[subKey]) && !_.isNull(data[subKey]) && _.isUndefined(data[subKey].length) && _.keys(data[subKey]).length > 0) { // If we have another nested document
             subKeys[indx] = retrieveSubHeading(newKey, data[subKey]); // Recur on the subdocument to retrieve the full key name
         } else {
             subKeys[indx] = (options.DELIMITER.WRAP || '') + (newKey || '') + (options.DELIMITER.WRAP || ''); // Set the key name since we don't have a sub document
@@ -22,21 +22,19 @@ var retrieveSubHeading = function (heading, data) {
 };
 
 // Retrieve the headings for all documents and return it.  This checks that all documents have the same schema.
-var retrieveHeading = function (data) {
-    return function (cb) { // Returns a function that takes a callback - the function is passed to async.parallel
-        var keys = _.keys(data); // Retrieve the current data keys
-        _.each(keys, function (key, indx) { // for each key
-            if (typeof data[key] === 'object') {
-                // if the data at the key is a document, then we retrieve the subHeading starting with an empty string heading and the doc
-                keys[indx] = retrieveSubHeading('', data[key]);
-            }
-        });
-        // Retrieve the unique array of headings (keys)
-        keys = _.uniq(keys);
-        // If we have more than 1 unique list, then not all docs have the same schema - report an error
-        if (keys.length > 1) { throw new Error('Not all documents have the same schema.', keys); }
-        return cb(null, _.flatten(keys).join(options.DELIMITER.FIELD)); // Return headings back
-    };
+var retrieveHeading = function (data, cb) {
+    var keys = _.keys(data); // Retrieve the current data keys
+    _.each(keys, function (key, indx) { // for each key
+        if (_.isObject(data[key])) {
+            // if the data at the key is a document, then we retrieve the subHeading starting with an empty string heading and the doc
+            keys[indx] = retrieveSubHeading('', data[key]);
+        }
+    });
+    // Retrieve the unique array of headings (keys)
+    keys = _.uniq(keys);
+    // If we have more than 1 unique list, then not all docs have the same schema - report an error
+    if (keys.length > 1) { throw new Error('Not all documents have the same schema.', keys); }
+    return cb(null, _.flatten(keys).join(options.DELIMITER.FIELD)); // Return headings back
 };
 
 // Convert the given data with the given keys
@@ -62,11 +60,9 @@ var convertData = function (data, keys) {
 };
 
 // Generate the CSV representing the given data.
-var generateCsv = function (data) {
-    return function (cb) { // Returns a function that takes a callback - the function is passed to async.parallel
-        // Reduce each JSON document in data to a CSV string and append it to the CSV accumulator
-        return cb(null, _.reduce(data, function (csv, doc) { return csv += convertData(doc, _.keys(doc)) + options.EOL; }, ''));
-    };
+var generateCsv = function (data, cb) {
+    // Reduce each JSON document in data to a CSV string and append it to the CSV accumulator
+    return cb(null, _.reduce(data, function (csv, doc) { return csv += convertData(doc, _.keys(doc)) + options.EOL; }, ''));
 };
 
 module.exports = {
@@ -78,13 +74,14 @@ module.exports = {
         if (!opts) { callback(new Error('Options were not passed and are required.')); return null; } // Shouldn't happen, but just in case
         else { options = opts; } // Options were passed, set the global options value
         if (!data) { callback(new Error('Cannot call json2csv on ' + data + '.')); return null; } // If we don't receive data, report an error
-        if (typeof data !== 'object') { // If the data was not a single document or an array of documents
+        if (!_.isObject(data)) { // If the data was not a single document or an array of documents
             return cb(new Error('Data provided was not an array of documents.'));  // Report the error back to the caller
-        } else if (typeof data === 'object' && !data.length) { // Single document, not an array
+        } else if (_.isObject(data) && !data.length) { // Single document, not an array
             data = [data]; // Convert to an array of the given document
         }
+
         // Retrieve the heading and the CSV asynchronously in parallel
-        async.parallel([retrieveHeading(data), generateCsv(data)], function (err, res) {
+        async.parallel([_.partial(retrieveHeading, data), _.partial(generateCsv, data)], function (err, res) {
             if (!err) {
                 // Data received with no errors, join the two responses with an end of line delimiter to setup heading and CSV body
                 return callback(null, res.join(options.EOL));

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "author": "mrodrig",
     "name": "json-2-csv",
     "description": "A JSON to CSV and CSV to JSON converter that natively supports sub-documents and auto-generates the CSV heading.",
-    "version": "1.0.8",
+    "version": "1.1.0",
     "repository": {
         "type": "git",
     	"url": "http://github.com/mrodrig/json-2-csv.git"
@@ -24,7 +24,7 @@
     ],
     "dependencies": {
     	"underscore": "1.6.0",
-    	"async": "0.2.10"
+        "bluebird": "~2.9.24"
     },
     "devDependencies": {
         "mocha": "~1.14.0",

--- a/test/JSON/differentSchemas.json
+++ b/test/JSON/differentSchemas.json
@@ -1,0 +1,6 @@
+[
+    { "carModel" : "Audi",      "price" : "10000",  "color" : "blue", "mileage" : "7200" },
+    { "carModel" : "BMW",       "price" : "15000",  "color" : "red" },
+    { "carModel" : "Mercedes",  "price" : "20000",  "color" : "yellow" },
+    { "carModel" : "Porsche",   "price" : "30000",  "color" : "green" }
+]

--- a/test/JSON/sameSchemaDifferentOrdering.json
+++ b/test/JSON/sameSchemaDifferentOrdering.json
@@ -1,0 +1,6 @@
+[
+    { "carModel" : "Audi",      "price" : "10000",  "color" : "blue" },
+    { "carModel" : "BMW",       "color" : "red",    "price" : "15000" },
+    { "price" : "20000",        "color" : "yellow", "carModel" : "Mercedes" },
+    { "carModel" : "Porsche",   "price" : "30000",  "color" : "green" }
+]

--- a/test/testComma.js
+++ b/test/testComma.js
@@ -1,8 +1,8 @@
 var should = require('should'),
-  converter = require('.././lib/converter'),
-  fs = require('fs'),
-  _ = require('underscore'),
-  async = require('async');
+    converter = require('.././lib/converter'),
+    fs = require('fs'),
+    _ = require('underscore'),
+    async = require('async');
 
 var options = {
     DELIMITER         : {
@@ -13,20 +13,22 @@ var options = {
     PARSE_CSV_NUMBERS : false
 };
 
-var json_regularJson    = require('./JSON/regularJson'),
-    json_nestedJson     = require('./JSON/nestedJson'),
-    json_nestedJson2    = require('./JSON/nestedJson2'),
-    json_nestedQuotes   = require('./JSON/nestedQuotes'),
-    json_noData         = require('./JSON/noData.json'),
-    json_singleDoc      = require('./JSON/singleDoc.json'),
-    json_arrayValue     = require('./JSON/arrayValueDocs.json'),
-    csv_regularJson     = '',
-    csv_nestedJson      = '',
-    csv_nestedJson2     = '',
-    csv_nestedQuotes    = '',
-    csv_noData          = '',
-    csv_singleDoc       = '',
-    csv_arrayValue      = '';
+var json_regularJson                 = require('./JSON/regularJson'),
+    json_nestedJson                  = require('./JSON/nestedJson'),
+    json_nestedJson2                 = require('./JSON/nestedJson2'),
+    json_nestedQuotes                = require('./JSON/nestedQuotes'),
+    json_noData                      = require('./JSON/noData.json'),
+    json_singleDoc                   = require('./JSON/singleDoc.json'),
+    json_arrayValue                  = require('./JSON/arrayValueDocs.json'),
+    json_sameSchemaDifferentOrdering = require('./JSON/sameSchemaDifferentOrdering'),
+    json_differentSchemas            = require('./JSON/differentSchemas'),
+    csv_regularJson                  = '',
+    csv_nestedJson                   = '',
+    csv_nestedJson2                  = '',
+    csv_nestedQuotes                 = '',
+    csv_noData                       = '',
+    csv_singleDoc                    = '',
+    csv_arrayValue                   = '';
 
 var json2csvTests = function () {
     describe('json2csv', function (done) {
@@ -79,10 +81,25 @@ var json2csvTests = function () {
                 }, options);
             });
 
-            it('should parse a single JSON document to CSV', function (done) {
+            it('should parse an array of JSON documents to CSV', function (done) {
                 converter.json2csv(json_arrayValue, function (err, csv) {
                     csv.should.equal(csv_arrayValue);
                     csv.split(options.EOL).length.should.equal(5);
+                    done();
+                }, options);
+            });
+
+            it('should parse an array of JSON documents with the same schema but different ordering of fields', function (done) {
+                converter.json2csv(json_sameSchemaDifferentOrdering, function (err, csv) {
+                    csv.should.equal(csv_regularJson);
+                    csv.split(options.EOL).length.should.equal(6);
+                    done();
+                }, options);
+            });
+
+            it('should throw an error if the documents do not have the same schema', function (done) {
+                converter.json2csv(json_differentSchemas, function (err, csv) {
+                    err.message.should.equal('Not all documents have the same schema.');
                     done();
                 }, options);
             });
@@ -187,10 +204,25 @@ var json2csvTests = function () {
                 });
             });
 
-            it('should parse a single JSON document to CSV', function (done) {
+            it('should parse an array of JSON documents to CSV', function (done) {
                 converter.json2csv(json_arrayValue, function (err, csv) {
                     csv.should.equal(csv_arrayValue.replace(/\//g, ';'));
                     csv.split(options.EOL).length.should.equal(5);
+                    done();
+                });
+            });
+
+            it('should parse an array of JSON documents with the same schema but different ordering of fields', function (done) {
+                converter.json2csv(json_sameSchemaDifferentOrdering, function (err, csv) {
+                    csv.should.equal(csv_regularJson);
+                    csv.split(options.EOL).length.should.equal(6);
+                    done();
+                });
+            });
+
+            it('should throw an error if the documents do not have the same schema', function (done) {
+                converter.json2csv(json_differentSchemas, function (err, csv) {
+                    err.message.should.equal('Not all documents have the same schema.');
                     done();
                 });
             });
@@ -491,62 +523,62 @@ module.exports = {
         describe('"," Delimited', function() {
             before(function(done) {
                 async.parallel([
-                    function(callback) {
-                        fs.readFile('test/CSV/regularJson.csv', function(err, data) {
-                            if (err) callback(err);
-                            csv_regularJson = data.toString();
-                            callback(null);
-                        });
-                    },
-                    function(callback) {
-                        fs.readFile('test/CSV/nestedJson.csv', function(err, data) {
-                            if (err) callback(err);
-                            csv_nestedJson = data.toString();
-                            callback(null);
-                        });
-                    },
-                    function(callback) {
-                        fs.readFile('test/CSV/nestedJson2.csv', function(err, data) {
-                            if (err) callback(err);
-                            csv_nestedJson2 = data.toString();
-                            callback(null);
-                        });
-                    },
-                    function(callback) {
-                        fs.readFile('test/CSV/nestedQuotes.csv', function(err, data) {
-                            if (err) callback(err);
-                            csv_nestedQuotes = data.toString();
-                            callback(null);
-                        });
-                    },
-                    function(callback) {
-                        fs.readFile('test/CSV/noData.csv', function (err, data) {
-                            if (err) callback(err);
-                            csv_noData = data.toString();
-                            callback(null);
-                        });
-                    },
-                    function(callback) {
-                        fs.readFile('test/CSV/singleDoc.csv', function (err, data) {
-                            if (err) callback(err);
-                            csv_singleDoc = data.toString();
-                            callback(null);
-                        });
-                    },
-                    function(callback) {
-                        fs.readFile('test/CSV/arrayValueDocs.csv', function (err, data) {
-                            if (err) callback(err);
-                            csv_arrayValue = data.toString();
-                            callback(null);
-                        });
+                        function(callback) {
+                            fs.readFile('test/CSV/regularJson.csv', function(err, data) {
+                                if (err) callback(err);
+                                csv_regularJson = data.toString();
+                                callback(null);
+                            });
+                        },
+                        function(callback) {
+                            fs.readFile('test/CSV/nestedJson.csv', function(err, data) {
+                                if (err) callback(err);
+                                csv_nestedJson = data.toString();
+                                callback(null);
+                            });
+                        },
+                        function(callback) {
+                            fs.readFile('test/CSV/nestedJson2.csv', function(err, data) {
+                                if (err) callback(err);
+                                csv_nestedJson2 = data.toString();
+                                callback(null);
+                            });
+                        },
+                        function(callback) {
+                            fs.readFile('test/CSV/nestedQuotes.csv', function(err, data) {
+                                if (err) callback(err);
+                                csv_nestedQuotes = data.toString();
+                                callback(null);
+                            });
+                        },
+                        function(callback) {
+                            fs.readFile('test/CSV/noData.csv', function (err, data) {
+                                if (err) callback(err);
+                                csv_noData = data.toString();
+                                callback(null);
+                            });
+                        },
+                        function(callback) {
+                            fs.readFile('test/CSV/singleDoc.csv', function (err, data) {
+                                if (err) callback(err);
+                                csv_singleDoc = data.toString();
+                                callback(null);
+                            });
+                        },
+                        function(callback) {
+                            fs.readFile('test/CSV/arrayValueDocs.csv', function (err, data) {
+                                if (err) callback(err);
+                                csv_arrayValue = data.toString();
+                                callback(null);
+                            });
+                        }
+                    ],
+                    function(err, results) {
+                        if (err) console.log(err);
+                        done();
                     }
-                ],
-                function(err, results) {
-                    if (err) console.log(err);
-                    done();
-                }
-            );
-        });
+                );
+            });
 
             // JSON to CSV
             json2csvTests();

--- a/test/testQuoted.js
+++ b/test/testQuoted.js
@@ -14,22 +14,24 @@ var options = {
     PARSE_CSV_NUMBERS : false
 };
 
-var json_regularJson    = require('./JSON/regularJson'),
-    json_nestedJson     = require('./JSON/nestedJson'),
-    json_nestedJson2    = require('./JSON/nestedJson2'),
-    json_nestedQuotes   = require('./JSON/nestedQuotes'),
-    json_nestedComma    = require('./JSON/nestedComma'),
-    json_noData         = require('./JSON/noData.json'),
-    json_singleDoc      = require('./JSON/singleDoc.json'),
-    json_arrayValue     = require('./JSON/arrayValueDocs.json'),
-    csv_regularJson     = '',
-    csv_nestedJson      = '',
-    csv_nestedJson2     = '',
-    csv_nestedQuotes    = '',
-    csv_nestedComma     = '',
-    csv_noData          = '',
-    csv_singleDoc       = '',
-    csv_arrayValue      = '';
+var json_regularJson                 = require('./JSON/regularJson'),
+    json_nestedJson                  = require('./JSON/nestedJson'),
+    json_nestedJson2                 = require('./JSON/nestedJson2'),
+    json_nestedQuotes                = require('./JSON/nestedQuotes'),
+    json_nestedComma                 = require('./JSON/nestedComma'),
+    json_noData                      = require('./JSON/noData.json'),
+    json_singleDoc                   = require('./JSON/singleDoc.json'),
+    json_arrayValue                  = require('./JSON/arrayValueDocs.json'),
+    json_sameSchemaDifferentOrdering = require('./JSON/sameSchemaDifferentOrdering'),
+    json_differentSchemas            = require('./JSON/differentSchemas'),
+    csv_regularJson                  = '',
+    csv_nestedJson                   = '',
+    csv_nestedJson2                  = '',
+    csv_nestedQuotes                 = '',
+    csv_nestedComma                  = '',
+    csv_noData                       = '',
+    csv_singleDoc                    = '',
+    csv_arrayValue                   = '';
 
 var json2csvTests = function () {
     describe('json2csv', function (done) {
@@ -90,10 +92,25 @@ var json2csvTests = function () {
                 }, options);
             });
 
-            it('should parse a single JSON document to CSV', function (done) {
+            it('should parse an array of JSON documents to CSV', function (done) {
                 converter.json2csv(json_arrayValue, function (err, csv) {
                     csv.should.equal(csv_arrayValue.replace(/,/g, options.DELIMITER.FIELD));
                     csv.split(options.EOL).length.should.equal(5);
+                    done();
+                }, options);
+            });
+
+            it('should parse an array of JSON documents with the same schema but different ordering of fields', function (done) {
+                converter.json2csv(json_sameSchemaDifferentOrdering, function (err, csv) {
+                    csv.should.equal(csv_regularJson);
+                    csv.split(options.EOL).length.should.equal(6);
+                    done();
+                }, options);
+            });
+
+            it('should throw an error if the documents do not have the same schema', function (done) {
+                converter.json2csv(json_differentSchemas, function (err, csv) {
+                    err.message.should.equal('Not all documents have the same schema.');
                     done();
                 }, options);
             });

--- a/test/testSemi.js
+++ b/test/testSemi.js
@@ -13,20 +13,22 @@ var options = {
     PARSE_CSV_NUMBERS : false
 };
 
-var json_regularJson    = require('./JSON/regularJson'),
-    json_nestedJson     = require('./JSON/nestedJson'),
-    json_nestedJson2    = require('./JSON/nestedJson2'),
-    json_nestedQuotes   = require('./JSON/nestedQuotes'),
-    json_noData         = require('./JSON/noData.json'),
-    json_singleDoc      = require('./JSON/singleDoc.json'),
-    json_arrayValue     = require('./JSON/arrayValueDocs.json'),
-    csv_regularJson     = '',
-    csv_nestedJson      = '',
-    csv_nestedJson2     = '',
-    csv_nestedQuotes    = '',
-    csv_noData          = '',
-    csv_singleDoc       = '',
-    csv_arrayValue      = '';
+var json_regularJson                 = require('./JSON/regularJson'),
+    json_nestedJson                  = require('./JSON/nestedJson'),
+    json_nestedJson2                 = require('./JSON/nestedJson2'),
+    json_nestedQuotes                = require('./JSON/nestedQuotes'),
+    json_noData                      = require('./JSON/noData.json'),
+    json_singleDoc                   = require('./JSON/singleDoc.json'),
+    json_arrayValue                  = require('./JSON/arrayValueDocs.json'),
+    json_sameSchemaDifferentOrdering = require('./JSON/sameSchemaDifferentOrdering'),
+    json_differentSchemas            = require('./JSON/differentSchemas'),
+    csv_regularJson                  = '',
+    csv_nestedJson                   = '',
+    csv_nestedJson2                  = '',
+    csv_nestedQuotes                 = '',
+    csv_noData                       = '',
+    csv_singleDoc                    = '',
+    csv_arrayValue                   = '';
 
 var json2csvTests = function () {
     describe('json2csv', function (done) {
@@ -79,10 +81,26 @@ var json2csvTests = function () {
                 }, options);
             });
 
-            it('should parse a single JSON document to CSV', function (done) {
+            it('should parse an array of JSON documents to CSV', function (done) {
                 converter.json2csv(json_arrayValue, function (err, csv) {
                     csv.should.equal(csv_arrayValue.replace(/,/g, options.DELIMITER.FIELD));
                     csv.split(options.EOL).length.should.equal(5);
+                    done();
+                }, options);
+            });
+
+
+            it('should parse an array of JSON documents with the same schema but different ordering of fields', function (done) {
+                converter.json2csv(json_sameSchemaDifferentOrdering, function (err, csv) {
+                    csv.should.equal(csv_regularJson.replace(/,/g, ';'));
+                    csv.split(options.EOL).length.should.equal(6);
+                    done();
+                }, options);
+            });
+
+            it('should throw an error if the documents do not have the same schema', function (done) {
+                converter.json2csv(json_differentSchemas, function (err, csv) {
+                    err.message.should.equal('Not all documents have the same schema.');
                     done();
                 }, options);
             });
@@ -188,10 +206,25 @@ var json2csvTests = function () {
                 });
             });
 
-            it('should parse a single JSON document to CSV', function (done) {
+            it('should parse an array of JSON documents to CSV', function (done) {
                 converter.json2csv(json_arrayValue, function (err, csv) {
                     csv.should.equal(csv_arrayValue.replace(/\//g, options.DELIMITER.FIELD));
                     csv.split(options.EOL).length.should.equal(5);
+                    done();
+                });
+            });
+
+            it('should parse an array of JSON documents with the same schema but different ordering of fields', function (done) {
+                converter.json2csv(json_sameSchemaDifferentOrdering, function (err, csv) {
+                    csv.should.equal(csv_regularJson);
+                    csv.split(options.EOL).length.should.equal(6);
+                    done();
+                });
+            });
+
+            it('should throw an error if the documents do not have the same schema', function (done) {
+                converter.json2csv(json_differentSchemas, function (err, csv) {
+                    err.message.should.equal('Not all documents have the same schema.');
                     done();
                 });
             });

--- a/test/todo.txt
+++ b/test/todo.txt
@@ -1,2 +1,0 @@
-single doc (not in array)
-check errors - no callback, not all same schema


### PR DESCRIPTION
In issue #12, Herve reported that he was receiving an error about his documents not having the same schema because the field ordering was different from document to document.  This is a bug and this PR will fix that issue.  While debugging and refactoring the code to fix the issue, I noticed that the options.DELIMITER object was not having the defaults properly set.  Issue #13 will also be fixed in this PR.

Tests were added to ensure that the schema errors do not crop back up in future releases.

This PR also sets up the ability to allow users to specify the keys that they would like to have converted which will likely be added in a future release.