### PR TITLE
Different schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ var converter = require('json-2-csv');
   * `KEYS` - Array - Specify the keys (as strings) that should be converted. Default: `null`
     * If you have a nested object (ie. {info : {name: 'Mike'}}), then set options.KEYS to ['info.name']
     * If you want all keys to be converted, then specify ```null``` or don't specify the option to utilize the default.
+  * `ALLOW_DIFFERENT_SCHEMAS` - Boolean - The parser first checks all documents on schema differences, it can accept missing or different fields and just add them as null values. Set this value to true to enable this behaviour. Default: false 
 
 ##### json2csv Example:
 

--- a/lib/constants.json
+++ b/lib/constants.json
@@ -8,9 +8,7 @@
     "json2csv": {
       "cannotCallJson2CsvOn": "Cannot call json2csv on ",
       "dataNotArrayOfDocuments": "Data provided was not an array of documents.",
-      "notSameSchema": "Not all documents have the same schema.",
-      "propertyLeafExpected": "The field used to contain a property leaf (object with nested properties) in previous documents. Types of fields must be the same.",
-      "valueExpected": "The field used to contain a value in previous document(s). Types of fields must be the same."
+      "notSameSchema": "Not all documents have the same schema."
     },
 
     "csv2json": {

--- a/lib/constants.json
+++ b/lib/constants.json
@@ -8,7 +8,9 @@
     "json2csv": {
       "cannotCallJson2CsvOn": "Cannot call json2csv on ",
       "dataNotArrayOfDocuments": "Data provided was not an array of documents.",
-      "notSameSchema": "Not all documents have the same schema."
+      "notSameSchema": "Not all documents have the same schema.",
+      "propertyLeafExpected": "The field used to contain a property leaf (object with nested properties) in previous documents. Types of fields must be the same.",
+      "valueExpected": "The field used to contain a value in previous document(s). Types of fields must be the same."
     },
 
     "csv2json": {

--- a/lib/json-2-csv.js
+++ b/lib/json-2-csv.js
@@ -19,14 +19,13 @@ var options = {}; // Initialize the options - this will be populated when the js
 var generateHeading = function(data) {
     if (options.KEYS) { return Promise.resolve(options.KEYS); }
 
-    var mergeStats = {totalFieldCount: 0, uniqueFieldCount: 0};
-    var mergedDocumentsSchema = schemaCombiner.buildCombinedDocumentSchema(data, mergeStats);
+    var mergedDocumentsSchema = schemaCombiner.buildCombinedDocumentSchema(data);
     var documentHeading = generateDocumentHeading('', mergedDocumentsSchema);
     var flatDocumentHeading = _.flatten(documentHeading);
 
     // Check the counters to see if we have schema differences.
     var schemaCount = _.where(data, function(document) { return _.isObject(data) }).length;
-    var schemaDifferences = Math.abs(mergeStats.totalFieldCount - (mergeStats.uniqueFieldCount * schemaCount));
+    var schemaDifferences = Math.abs(mergedDocumentsSchema.totals.fieldCount - (mergedDocumentsSchema.totals.uniqueFieldCount * schemaCount));
 
     if (schemaDifferences > 0 && !options.ALLOW_DIFFERENT_SCHEMAS) {
         return Promise.reject(new Error(constants.Errors.json2csv.notSameSchema));
@@ -49,15 +48,15 @@ var generateDocumentHeading = function(heading, data) {
         keyName = heading ? heading + '.' + currentKey : currentKey;
 
         // If we have another nested document, recur on the sub-document to retrieve the full key name
-        if (data.fields[currentKey].isNested) {
-            if (data.fields[currentKey].isValue && !data.fields[currentKey].valueAlwaysNull) {
+        if (data.fields[currentKey].objects.count > 0) {
+            if (data.fields[currentKey].primitives.filledCount > 0) {
                 return [
                     keyName,
-                    generateDocumentHeading(keyName, data.fields[currentKey])
+                    generateDocumentHeading(keyName, data.fields[currentKey].objects)
                 ];
             }
             else {
-                return generateDocumentHeading(keyName, data.fields[currentKey]);
+                return generateDocumentHeading(keyName, data.fields[currentKey].objects);
             }
 
         }
@@ -88,25 +87,25 @@ var convertData = function (data, keys) {
  * @param output
  */
 var convertField = function (value) {
-    var stringifiedValue = '';
+    var stringValue = '';
 
-    if (_.isArray(value)) { // We have an array of values
-        stringifiedValue = '[' + value.join(options.DELIMITER.ARRAY) + ']'; // Should we also walk through internal values then?
+    if (_.isArray(value)) {
+        stringValue = '[' + value.join(options.DELIMITER.ARRAY) + ']'; // Should we also walk through internal values then?
     }
-    else if (_.isDate(value)) { // If we have a date
-        stringifiedValue = value.toISOString();      //TODO: toString to toISOString() as a setting???, false should also be a specific string!
-        // What kind of other minor things did we have?
+    else if (_.isDate(value)) {
+        stringValue = value.toString();
+        //stringifiedValue = value.toISOString();   // Could be an intresting setting as well. Let's keep it to wat it was for now.
     }
-    else if (_.isObject(value)) { // If we have an object
-        //stringifiedValue = options.DELIMITER.WRAP + convertData(value, _.keys(value)) + options.DELIMITER.WRAP; // Push the recursively generated CSV
-        // Just don't do a thing, strictly follow the list with fields that we already got! We don't want values for things that don't exist in this line.
+    else if (_.isObject(value)) {
+        // Don't do a thing, strictly follow the list with fields that we already got!
     }
     else if (!_.isUndefined(value) && !_.isNull(value))
     {
-        stringifiedValue = value.toString();
+        stringValue = value.toString();
     }
 
-    return options.DELIMITER.WRAP + stringifiedValue + options.DELIMITER.WRAP; // Otherwise push the current value
+    // We might want to leave out the delimiters in case of null, interesting read on this: http://www.garretwilson.com/blog/2009/04/23/csvnull.xhtml
+    return options.DELIMITER.WRAP + stringValue + options.DELIMITER.WRAP; // Otherwise push the current value
 };
 
 /**

--- a/lib/json-2-csv.js
+++ b/lib/json-2-csv.js
@@ -50,7 +50,16 @@ var generateDocumentHeading = function(heading, data) {
 
         // If we have another nested document, recur on the sub-document to retrieve the full key name
         if (data.fields[currentKey].isNested) {
-            return generateDocumentHeading(keyName, data.fields[currentKey]);
+            if (data.fields[currentKey].isValue && !data.fields[currentKey].valueAlwaysNull) {
+                return [
+                    keyName,
+                    generateDocumentHeading(keyName, data.fields[currentKey])
+                ];
+            }
+            else {
+                return generateDocumentHeading(keyName, data.fields[currentKey]);
+            }
+
         }
         // Otherwise return this key name since we don't have a sub document
         return keyName;
@@ -79,14 +88,25 @@ var convertData = function (data, keys) {
  * @param output
  */
 var convertField = function (value) {
+    var stringifiedValue = '';
+
     if (_.isArray(value)) { // We have an array of values
-        return options.DELIMITER.WRAP + '[' + value.join(options.DELIMITER.ARRAY) + ']' + options.DELIMITER.WRAP;
-    } else if (_.isDate(value)) { // If we have a date
-        return options.DELIMITER.WRAP + value.toString() + options.DELIMITER.WRAP;
-    } else if (_.isObject(value)) { // If we have an object
-        return options.DELIMITER.WRAP + convertData(value, _.keys(value)) + options.DELIMITER.WRAP; // Push the recursively generated CSV
+        stringifiedValue = '[' + value.join(options.DELIMITER.ARRAY) + ']'; // Should we also walk through internal values then?
     }
-    return options.DELIMITER.WRAP + (value ? value.toString() : '') + options.DELIMITER.WRAP; // Otherwise push the current value
+    else if (_.isDate(value)) { // If we have a date
+        stringifiedValue = value.toISOString();      //TODO: toString to toISOString() as a setting???, false should also be a specific string!
+        // What kind of other minor things did we have?
+    }
+    else if (_.isObject(value)) { // If we have an object
+        //stringifiedValue = options.DELIMITER.WRAP + convertData(value, _.keys(value)) + options.DELIMITER.WRAP; // Push the recursively generated CSV
+        // Just don't do a thing, strictly follow the list with fields that we already got! We don't want values for things that don't exist in this line.
+    }
+    else if (!_.isUndefined(value) && !_.isNull(value))
+    {
+        stringifiedValue = value.toString();
+    }
+
+    return options.DELIMITER.WRAP + stringifiedValue + options.DELIMITER.WRAP; // Otherwise push the current value
 };
 
 /**

--- a/lib/json-2-csv.js
+++ b/lib/json-2-csv.js
@@ -2,6 +2,7 @@
 
 var _ = require('underscore'),
     constants = require('./constants'),
+    schemaCombiner = require('./schema-combiner'),
     path = require('doc-path'),
     Promise = require('bluebird');
 
@@ -9,41 +10,29 @@ var options = {}; // Initialize the options - this will be populated when the js
 
 /**
  * Retrieve the headings for all documents and return it.
- * This checks that all documents have the same schema.
+ * The headings are placed on order of appearance.
+ * Nested schemas are placed together, also when using documents with a different schema.
+ * This also checks that all documents have the same schema if required.
  * @param data
  * @returns {Promise}
  */
 var generateHeading = function(data) {
     if (options.KEYS) { return Promise.resolve(options.KEYS); }
 
-    var keys = _.map(data, function (document, indx) { // for each key
-        if (_.isObject(document)) {
-            // if the data at the key is a document, then we retrieve the subHeading starting with an empty string heading and the doc
-            return generateDocumentHeading('', document);
-        }
-    });
+    var mergeStats = {totalFieldCount: 0, uniqueFieldCount: 0};
+    var mergedDocumentsSchema = schemaCombiner.buildCombinedDocumentSchema(data, mergeStats);
+    var documentHeading = generateDocumentHeading('', mergedDocumentsSchema);
+    var flatDocumentHeading = _.flatten(documentHeading);
 
-    // Check for a consistent schema that does not require the same order:
-    // if we only have one document - then there is no possibility of multiple schemas
-    if (keys && keys.length <= 1) {
-        return Promise.resolve(_.flatten(keys) || []);
+    // Check the counters to see if we have schema differences.
+    var schemaCount = _.where(data, function(document) { return _.isObject(data) }).length;
+    var schemaDifferences = Math.abs(mergeStats.totalFieldCount - (mergeStats.uniqueFieldCount * schemaCount));
+
+    if (schemaDifferences > 0 && !options.ALLOW_DIFFERENT_SCHEMAS) {
+        return Promise.reject(new Error(constants.Errors.json2csv.notSameSchema));
     }
-    // else - multiple documents - ensure only one schema (regardless of field ordering)
-    var firstDocSchema = _.flatten(keys[0]),
-        schemaDifferences = 0;
 
-    _.each(keys, function (keyList) {
-        // If there is a difference between the schemas, increment the counter of schema inconsistencies
-        var diff = _.difference(firstDocSchema, _.flatten(keyList));
-        if (!_.isEqual(diff, [])) {
-            schemaDifferences++;
-        }
-    });
-
-    // If there are schema inconsistencies, throw a schema not the same error
-    if (schemaDifferences) { return Promise.reject(new Error(constants.Errors.json2csv.notSameSchema)); }
-
-    return Promise.resolve(_.flatten(keys[0]));
+    return Promise.resolve(flatDocumentHeading);
 };
 
 /**
@@ -55,13 +44,13 @@ var generateHeading = function(data) {
 var generateDocumentHeading = function(heading, data) {
     var keyName = ''; // temporary variable to aid in determining the heading - used to generate the 'nested' headings
 
-    var documentKeys = _.map(_.keys(data), function (currentKey) {
+    var documentKeys = _.map(_.keys(data.fields), function (currentKey) {
         // If the given heading is empty, then we set the heading to be the subKey, otherwise set it as a nested heading w/ a dot
         keyName = heading ? heading + '.' + currentKey : currentKey;
 
         // If we have another nested document, recur on the sub-document to retrieve the full key name
-        if (_.isObject(data[currentKey]) && !_.isNull(data[currentKey]) && _.isUndefined(data[currentKey].length) && _.keys(data[currentKey]).length) {
-            return generateDocumentHeading(keyName, data[currentKey]);
+        if (data.fields[currentKey].isNested) {
+            return generateDocumentHeading(keyName, data.fields[currentKey]);
         }
         // Otherwise return this key name since we don't have a sub document
         return keyName;

--- a/lib/schema-combiner.js
+++ b/lib/schema-combiner.js
@@ -9,11 +9,19 @@ var constants = require('./constants');
  * @param documents The array with 1..n documents that is to be processed.
  * @returns A document with all properties that where found in the given set of documents.
  */
-var buildCombinedDocumentSchema = function(documents, mergeStats) {
-    var result = {isNested: true, fields: {}, isValue: false, valueCount: 0, valueAlwaysNull: null};
+var buildCombinedDocumentSchema = function(documents) {
+    var result = {
+        totals: {
+            uniqueFieldCount: 0,
+            fieldCount: 0
+        },
+        fields: {
+        }
+    };
+
     _.each(documents, function(document) {
         if (_.isObject(document)) {
-            collectAndCountObjectFields(document, result, mergeStats);
+            collectAndCountObjectFields(document, result, result.totals);
         }
     });
 
@@ -21,7 +29,7 @@ var buildCombinedDocumentSchema = function(documents, mergeStats) {
 };
 
 /**
- * Does a value contain other properties? At this moment we only allow this for objects. Not for functions and arrays.
+ * Does a value contain other fields? At this moment we only allow this for objects. Not for functions and arrays.
  * @param value Reference to the value that you want to check.
  * @returns {boolean} that is true when properties may exist.
  */
@@ -34,34 +42,37 @@ var isPropertyParent = function(value) {
  * @param inputObject The object that you want to examine.
  * @param result The result document that the properties are written to, if a field already is available then it's counter is increased.
  */
-var collectAndCountObjectFields = function(inputObject, result, mergeStats) {
+var collectAndCountObjectFields = function(inputObject, result, totals) {
     _.each(_.keys(inputObject), function(key) {
-        if (isPropertyParent(inputObject[key])) {
-            // Check if it's not a value already.
-            var createNewNested = false;
-            if (!_.has(result.fields, key)) {
-                result.fields[key] = {isNested: true, fields: {}, isValue: false, valueCount: 0, valueAlwaysNull: null};
-            }
+        // We have another fields, always counts from now on.
+        totals.fieldCount++;
 
-            result.fields[key].isNested = true;
-            collectAndCountObjectFields(inputObject[key], result.fields[key], mergeStats);
+        // Check if we already have something in our results for this? If not then we should add our default
+        if (!_.has(result.fields, key)){
+            result.fields[key] = {
+                primitives: {
+                    emptyCount: 0,
+                    filledCount: 0
+                },
+                objects: {
+                    count: 0,
+                    fields: {}
+                }
+            };
+
+            totals.uniqueFieldCount++;
+        }
+
+        if (isPropertyParent(inputObject[key])) {
+            result.fields[key].objects.count++;
+            collectAndCountObjectFields(inputObject[key], result.fields[key].objects, totals);
         }
         else {
-            // Check if we already have the key in our result, otherwise add it with a value of 1.
-            if (_.has(result.fields, key)) {
-                result.fields[key].isValue = true;
-                result.fields[key].valueCount++;
-                mergeStats.totalFieldCount++;
-
-                // Replace the value with the current state when this is the first value, or when the value is true.
-                if (result.fields[key].valueAlwaysNull == null || result.fields[key].valueAlwaysNull == true) {
-                    result.fields[key].valueAlwaysNull = _.isNull(inputObject[key]);
-                }
+            if (_.isNull(inputObject[key]) || _.isUndefined(inputObject[key])) {
+                result.fields[key].primitives.emptyCount++;
             }
             else {
-                result.fields[key] = {isNested: false, fields: {}, isValue: true, valueCount: 1, valueAlwaysNull: _.isNull(inputObject[key])};
-                mergeStats.uniqueFieldCount++;
-                mergeStats.totalFieldCount++;
+                result.fields[key].primitives.filledCount++;
             }
         }
     });

--- a/lib/schema-combiner.js
+++ b/lib/schema-combiner.js
@@ -1,0 +1,93 @@
+'use-strict';
+
+var _ = require('underscore');
+
+/**
+ * Build a 'schema' document with all field names that are avaialble in a list with documents. Runs recursive.
+ * Every field name will also contain a count, so that you can deduce how many times a certain property has been used in the set of documents.
+ * @param documents The array with 1..n documents that is to be processed.
+ * @returns A document with all properties that where found in the given set of documents.
+ */
+var buildCombinedDocumentSchema = function(documents, mergeStats) {
+    var result = {isNested: true, fields: {}};
+    _.each(documents, function(document) {
+        if (_.isObject(document)) {
+            collectAndCountObjectFields(document, result, mergeStats);
+        }
+    });
+
+    return result;
+};
+
+/**
+ * Does a value contain other properties? At this moment we only allow this for objects. Not for functions and arrays.
+ * @param value Reference to the value that you want to check.
+ * @returns {boolean} that is true when properties may exist.
+ */
+var isPropertyParent = function(value) {
+    return (_.isObject(value) && !_.isArray(value)) && !_.isFunction(value);
+}
+
+/**
+ * Collects and counts the fields inside an object. Runs recursively.
+ * @param inputObject The object that you want to examine.
+ * @param result The result document that the properties are written to, if a field already is avaialble then it's counter is increased.
+ */
+var collectAndCountObjectFields = function(inputObject, result, mergeStats) {
+    _.each(_.keys(inputObject), function(key) {
+        if (isPropertyParent(inputObject[key])) {
+            // Check if it's not a value already.
+            var createNewNested = false;
+            if (_.has(result.fields, key)) {
+                if (result.fields[key].isNested) {
+                    collectAndCountObjectFields(inputObject[key], result.fields[key], mergeStats);
+                }
+                else {
+                    if (result.fields[key].alwaysNull) {
+                        // We can upgrade the value to a leaf, previous documents just didn't had the object filled in.
+                        mergeStats.uniqueFieldCount--;
+                        mergeStats.totalFieldCount -= result.fields[key].count;
+                        createNewNested = true;
+                    }
+                    else {
+                        // Don't use different types for the same field in your array with documents.
+                        throw new Error(constants.Errors.json2csv.propertyLeafExpected);
+                    }
+                }
+            }
+            else {
+                createNewNested = true;
+            }
+
+            if (createNewNested) {
+                result.fields[key] = {isNested: true, fields: {}};
+                collectAndCountObjectFields(inputObject[key], result.fields[key], mergeStats);
+            }
+        }
+        else {
+            // Check if we already have the key in our result, otherwise add it with a value of 1.
+            if (_.has(result.fields, key)) {
+                if (result.fields[key].isNested) {
+                    if (!_.isNull(inputObject[key])) {
+                        throw new Error(constants.Errors.json2csv.valueExpected);
+                    }
+                }
+                else {
+                    result.fields[key].count++;
+                    if (!_.isNull(inputObject[key])) {
+                        result.fields[key].alwaysNull = false;
+                    }
+
+                    mergeStats.totalFieldCount++;
+                }
+            }
+            else {
+                result.fields[key] = {isNested: false, alwaysNull: _.isNull(inputObject[key]), count: 1};
+                mergeStats.uniqueFieldCount++;
+                mergeStats.totalFieldCount++;
+            }
+        }
+    });
+}
+
+module.exports.buildCombinedDocumentSchema = buildCombinedDocumentSchema;

--- a/lib/schema-combiner.js
+++ b/lib/schema-combiner.js
@@ -1,15 +1,16 @@
 'use-strict';
 
 var _ = require('underscore');
+var constants = require('./constants');
 
 /**
- * Build a 'schema' document with all field names that are avaialble in a list with documents. Runs recursive.
- * Every field name will also contain a count, so that you can deduce how many times a certain property has been used in the set of documents.
+ * Build a 'schema' document with all field names that are available in a list with documents. Runs recursive.
+ * Every field name will also contain a valueCount, so that you can deduce how many times a certain property has been used in the set of documents.
  * @param documents The array with 1..n documents that is to be processed.
  * @returns A document with all properties that where found in the given set of documents.
  */
 var buildCombinedDocumentSchema = function(documents, mergeStats) {
-    var result = {isNested: true, fields: {}};
+    var result = {isNested: true, fields: {}, isValue: false, valueCount: 0, valueAlwaysNull: null};
     _.each(documents, function(document) {
         if (_.isObject(document)) {
             collectAndCountObjectFields(document, result, mergeStats);
@@ -31,58 +32,34 @@ var isPropertyParent = function(value) {
 /**
  * Collects and counts the fields inside an object. Runs recursively.
  * @param inputObject The object that you want to examine.
- * @param result The result document that the properties are written to, if a field already is avaialble then it's counter is increased.
+ * @param result The result document that the properties are written to, if a field already is available then it's counter is increased.
  */
 var collectAndCountObjectFields = function(inputObject, result, mergeStats) {
     _.each(_.keys(inputObject), function(key) {
         if (isPropertyParent(inputObject[key])) {
             // Check if it's not a value already.
             var createNewNested = false;
-            if (_.has(result.fields, key)) {
-                if (result.fields[key].isNested) {
-                    collectAndCountObjectFields(inputObject[key], result.fields[key], mergeStats);
-                }
-                else {
-                    if (result.fields[key].alwaysNull) {
-                        // We can upgrade the value to a leaf, previous documents just didn't had the object filled in.
-                        mergeStats.uniqueFieldCount--;
-                        mergeStats.totalFieldCount -= result.fields[key].count;
-                        createNewNested = true;
-                    }
-                    else {
-                        // Don't use different types for the same field in your array with documents.
-                        throw new Error(constants.Errors.json2csv.propertyLeafExpected);
-                    }
-                }
-            }
-            else {
-                createNewNested = true;
+            if (!_.has(result.fields, key)) {
+                result.fields[key] = {isNested: true, fields: {}, isValue: false, valueCount: 0, valueAlwaysNull: null};
             }
 
-            if (createNewNested) {
-                result.fields[key] = {isNested: true, fields: {}};
-                collectAndCountObjectFields(inputObject[key], result.fields[key], mergeStats);
-            }
+            result.fields[key].isNested = true;
+            collectAndCountObjectFields(inputObject[key], result.fields[key], mergeStats);
         }
         else {
             // Check if we already have the key in our result, otherwise add it with a value of 1.
             if (_.has(result.fields, key)) {
-                if (result.fields[key].isNested) {
-                    if (!_.isNull(inputObject[key])) {
-                        throw new Error(constants.Errors.json2csv.valueExpected);
-                    }
-                }
-                else {
-                    result.fields[key].count++;
-                    if (!_.isNull(inputObject[key])) {
-                        result.fields[key].alwaysNull = false;
-                    }
+                result.fields[key].isValue = true;
+                result.fields[key].valueCount++;
+                mergeStats.totalFieldCount++;
 
-                    mergeStats.totalFieldCount++;
+                // Replace the value with the current state when this is the first value, or when the value is true.
+                if (result.fields[key].valueAlwaysNull == null || result.fields[key].valueAlwaysNull == true) {
+                    result.fields[key].valueAlwaysNull = _.isNull(inputObject[key]);
                 }
             }
             else {
-                result.fields[key] = {isNested: false, alwaysNull: _.isNull(inputObject[key]), count: 1};
+                result.fields[key] = {isNested: false, fields: {}, isValue: true, valueCount: 1, valueAlwaysNull: _.isNull(inputObject[key])};
                 mergeStats.uniqueFieldCount++;
                 mergeStats.totalFieldCount++;
             }

--- a/test/CSV/quoted/differentSchemas.csv
+++ b/test/CSV/quoted/differentSchemas.csv
@@ -1,0 +1,5 @@
+"carModel","price","color","mileage"
+"Audi","10000","blue","7200"
+"BMW","15000","red",""
+"Mercedes","20000","yellow",""
+"Porsche","30000","green",""

--- a/test/CSV/quoted/differentSchemasFieldTypes.csv
+++ b/test/CSV/quoted/differentSchemasFieldTypes.csv
@@ -1,0 +1,3 @@
+"carModel","carModel.manufacturer","price","price.currency","price.amount","rating"
+"VW","","","USD",8000,"C"
+"","Audi",17600,"","","8"

--- a/test/CSV/quoted/differentSchemasNested.csv
+++ b/test/CSV/quoted/differentSchemasNested.csv
@@ -1,0 +1,6 @@
+"carModel","nestedInfo.price","nestedInfo.mileage","nestedInfo.color","nestedInfo.weight","sold"
+"Audi","10000","7200","","","yes"
+"BMW","10000","2430","red","1027",""
+"Mercedes","20000","","yellow","",""
+"Porsche","30000","","green","",""
+"Buick","","","","",""

--- a/test/CSV/quoted/differentSchemasNullUpgrade.csv
+++ b/test/CSV/quoted/differentSchemasNullUpgrade.csv
@@ -1,0 +1,3 @@
+"carModel","nestedInfo.price","nestedInfo.mileage"
+"VW","",""
+"Audi","10000","7200"

--- a/test/CSV/quoted/false0null.csv
+++ b/test/CSV/quoted/false0null.csv
@@ -1,0 +1,2 @@
+"field-false","field-0","field-null"
+"false","0",""

--- a/test/CSV/unQuoted/differentSchemas.csv
+++ b/test/CSV/unQuoted/differentSchemas.csv
@@ -1,0 +1,5 @@
+carModel,price,color,mileage
+Audi,10000,blue,7200
+BMW,15000,red,
+Mercedes,20000,yellow,
+Porsche,30000,green,

--- a/test/CSV/unQuoted/differentSchemasNested.csv
+++ b/test/CSV/unQuoted/differentSchemasNested.csv
@@ -1,0 +1,6 @@
+carModel,nestedInfo.price,nestedInfo.mileage,nestedInfo.color,nestedInfo.weight,sold
+Audi,10000,7200,,,yes
+BMW,10000,2430,red,1027,
+Mercedes,20000,,yellow,,
+Porsche,30000,,green,,
+Buick,,,,,

--- a/test/CSV/unQuoted/differentSchemasNullUpgrade.csv
+++ b/test/CSV/unQuoted/differentSchemasNullUpgrade.csv
@@ -1,0 +1,3 @@
+carModel,nestedInfo.price,nestedInfo.mileage
+VW,,
+Audi,10000,7200

--- a/test/JSON/differentSchemasFieldTypes.json
+++ b/test/JSON/differentSchemasFieldTypes.json
@@ -1,0 +1,4 @@
+[
+    { "carModel" : "VW",                     "price":   {"currency" : "USD", "amount": 8000}, "rating": "C" },
+    { "carModel" : {"manufacturer": "Audi"}, "price":   17600,                                "rating": 8   }
+]

--- a/test/JSON/differentSchemasNested.json
+++ b/test/JSON/differentSchemasNested.json
@@ -1,0 +1,7 @@
+[
+    { "carModel" : "Audi",      "nestedInfo":   { "price" : "10000", "mileage" : "7200" }, "sold" : "yes" },
+    { "carModel" : "BMW",       "nestedInfo":   { "price" : "10000", "color" : "red", "mileage" : "2430", "weight" : "1027" } },
+    { "carModel" : "Mercedes",  "nestedInfo":   { "price" : "20000", "color" : "yellow" } },
+    { "carModel" : "Porsche",   "nestedInfo":   { "price" : "30000", "color" : "green" } },
+    { "carModel" : "Buick",     "nestedInfo":   null }
+]

--- a/test/JSON/differentSchemasNullUpgrade.json
+++ b/test/JSON/differentSchemasNullUpgrade.json
@@ -1,0 +1,4 @@
+[
+    { "carModel" : "VW",        "nestedInfo":   null },
+    { "carModel" : "Audi",      "nestedInfo":   { "price" : "10000", "mileage" : "7200" }}
+]

--- a/test/JSON/false0null.json
+++ b/test/JSON/false0null.json
@@ -1,0 +1,5 @@
+{
+  "field-false": false,
+  "field-0": 0,
+  "field-null": null
+}

--- a/test/testCsvFilesList.json
+++ b/test/testCsvFilesList.json
@@ -9,7 +9,10 @@
       {"key": "nestedQuotes", "file": "test/CSV/unQuoted/nestedQuotes.csv"},
       {"key": "noData", "file": "test/CSV/unQuoted/noData.csv"},
       {"key": "regularJson", "file": "test/CSV/unQuoted/regularJson.csv"},
-      {"key": "singleDoc", "file": "test/CSV/unQuoted/singleDoc.csv"}
+      {"key": "singleDoc", "file": "test/CSV/unQuoted/singleDoc.csv"},
+      {"key": "differentSchemas", "file": "test/CSV/unQuoted/differentSchemas.csv"},
+      {"key": "differentSchemasNested", "file": "test/CSV/unQuoted/differentSchemasNested.csv"},
+      {"key": "differentSchemasNullUpgrade", "file": "test/CSV/unQuoted/differentSchemasNullUpgrade.csv"}
     ]
   },
   {
@@ -24,7 +27,10 @@
       {"key": "nestedQuotes", "file": "test/CSV/quoted/nestedQuotes.csv"},
       {"key": "noData", "file": "test/CSV/quoted/noData.csv"},
       {"key": "regularJson", "file": "test/CSV/quoted/regularJson.csv"},
-      {"key": "singleDoc", "file": "test/CSV/quoted/singleDoc.csv"}
+      {"key": "singleDoc", "file": "test/CSV/quoted/singleDoc.csv"},
+      {"key": "differentSchemas", "file": "test/CSV/quoted/differentSchemas.csv"},
+      {"key": "differentSchemasNested", "file": "test/CSV/quoted/differentSchemasNested.csv"},
+      {"key": "differentSchemasNullUpgrade", "file": "test/CSV/quoted/differentSchemasNullUpgrade.csv"}
     ]
   }
 ]

--- a/test/testCsvFilesList.json
+++ b/test/testCsvFilesList.json
@@ -29,6 +29,7 @@
       {"key": "regularJson", "file": "test/CSV/quoted/regularJson.csv"},
       {"key": "singleDoc", "file": "test/CSV/quoted/singleDoc.csv"},
       {"key": "differentSchemas", "file": "test/CSV/quoted/differentSchemas.csv"},
+      {"key": "differentSchemasFieldTypes", "file": "test/CSV/quoted/differentSchemasFieldTypes.csv"},
       {"key": "differentSchemasNested", "file": "test/CSV/quoted/differentSchemasNested.csv"},
       {"key": "differentSchemasNullUpgrade", "file": "test/CSV/quoted/differentSchemasNullUpgrade.csv"}
     ]

--- a/test/testCsvFilesList.json
+++ b/test/testCsvFilesList.json
@@ -31,7 +31,8 @@
       {"key": "differentSchemas", "file": "test/CSV/quoted/differentSchemas.csv"},
       {"key": "differentSchemasFieldTypes", "file": "test/CSV/quoted/differentSchemasFieldTypes.csv"},
       {"key": "differentSchemasNested", "file": "test/CSV/quoted/differentSchemasNested.csv"},
-      {"key": "differentSchemasNullUpgrade", "file": "test/CSV/quoted/differentSchemasNullUpgrade.csv"}
+      {"key": "differentSchemasNullUpgrade", "file": "test/CSV/quoted/differentSchemasNullUpgrade.csv"},
+      {"key": "false0null", "file": "test/CSV/quoted/false0null.csv"}
     ]
   }
 ]

--- a/test/testJson2Csv.js
+++ b/test/testJson2Csv.js
@@ -96,6 +96,7 @@ var json2csvTests = function () {
                 });
             });
 
+            // simon
             it('should throw an error if the documents do not have the same schema', function (done) {
                 converter.json2csv(jsonTestData.differentSchemas, function (err, csv) {
                     err.message.should.equal(constants.Errors.json2csv.notSameSchema);
@@ -267,9 +268,41 @@ var json2csvTests = function () {
                 }, options);
             });
 
+            it('should parse different schemas when requested', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csv(jsonTestData.differentSchemas, function (err, csv) {
+                    if (err) { throw err; }
+                    true.should.equal(_.isEqual(err, null));
+                    csv.should.equal(csvTestData.unQuoted.differentSchemas);
+                    csv.split(options.EOL).length.should.equal(6);
+                    done();
+                }, options);
+            });
+
+            it('should parse different schemas (only at nesting level) when requested', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csv(jsonTestData.differentSchemasNested, function (err, csv) {
+                    if (err) { throw err; }
+                    true.should.equal(_.isEqual(err, null));
+                    csv.should.equal(csvTestData.unQuoted.differentSchemasNested);
+                    csv.split(options.EOL).length.should.equal(7);
+                    done();
+                }, options);
+            });
+
+            it("should parse different schemas that 'upgrade' from a null value to an nested object.", function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csv(jsonTestData.differentSchemasNullUpgrade, function (err, csv) {
+                    if (err) { throw err; }
+                    true.should.equal(_.isEqual(err, null));
+                    csv.should.equal(csvTestData.unQuoted.differentSchemasNullUpgrade);
+                    csv.split(options.EOL).length.should.equal(4);
+                    done();
+                }, options);
+            });
+
             it('should repress the heading', function (done) {
-                opts = JSON.parse(JSON.stringify(options));
-                opts.PREPEND_HEADER = false;
+                options.PREPEND_HEADER = false;
 
                 converter.json2csv(jsonTestData.sameSchemaDifferentOrdering, function (err, csv) {
                     if (err) { throw err; }
@@ -277,9 +310,10 @@ var json2csvTests = function () {
                     csv.should.equal(csvTestData.unQuoted.regularJson.split(options.EOL).slice(1).join(options.EOL));
                     csv.split(options.EOL).length.should.equal(5);
                     done();
-                }, opts);
+                }, options);
             });
 
+            // simon
             it('should throw an error if the documents do not have the same schema', function (done) {
                 converter.json2csv(jsonTestData.differentSchemas, function (err, csv) {
                     err.message.should.equal(constants.Errors.json2csv.notSameSchema);
@@ -443,9 +477,41 @@ var json2csvTests = function () {
                 }, options);
             });
 
+            it('should parse different schemas when requested', function(done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csv(jsonTestData.differentSchemas, function(err, csv) {
+                    if (err) { throw err; }
+                    true.should.equal(_.isEqual(err, null));
+                    csv.should.equal(csvTestData.unQuoted.differentSchemas.replace(new RegExp(defaultOptions.DELIMITER.FIELD, 'g'), options.DELIMITER.FIELD));
+                    csv.split(options.EOL).length.should.equal(6);
+                    done();
+                }, options)
+            });
+
+            it('should parse different schemas (only at nesting level) when requested', function(done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csv(jsonTestData.differentSchemasNested, function(err, csv) {
+                    if (err) { throw err; }
+                    true.should.equal(_.isEqual(err, null));
+                    csv.should.equal(csvTestData.unQuoted.differentSchemasNested.replace(new RegExp(defaultOptions.DELIMITER.FIELD, 'g'), options.DELIMITER.FIELD));
+                    csv.split(options.EOL).length.should.equal(7);
+                    done();
+                }, options)
+            });
+
+            it("should parse different schemas that 'upgrade' from a null value to an nested object.", function(done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csv(jsonTestData.differentSchemasNullUpgrade, function(err, csv) {
+                    if (err) { throw err; }
+                    true.should.equal(_.isEqual(err, null));
+                    csv.should.equal(csvTestData.unQuoted.differentSchemasNullUpgrade.replace(new RegExp(defaultOptions.DELIMITER.FIELD, 'g'), options.DELIMITER.FIELD));
+                    csv.split(options.EOL).length.should.equal(4);
+                    done();
+                }, options)
+            });
+
             it('should repress the heading', function (done) {
-                opts = JSON.parse(JSON.stringify(options));
-                opts.PREPEND_HEADER = false;
+                options.PREPEND_HEADER = false;
 
                 converter.json2csv(jsonTestData.sameSchemaDifferentOrdering, function (err, csv) {
                     if (err) { throw err; }
@@ -453,10 +519,18 @@ var json2csvTests = function () {
                     csv.should.equal(csvTestData.unQuoted.regularJson.replace(/,/g, options.DELIMITER.FIELD).split(options.EOL).slice(1).join(options.EOL));
                     csv.split(options.EOL).length.should.equal(5);
                     done();
-                }, opts);
+                }, options);
+            });
+
+            it('should throw an error if the documents are not the same by default', function (done) {
+                converter.json2csv(jsonTestData.differentSchemas, function (err, csv) {
+                    err.message.should.equal(constants.Errors.json2csv.notSameSchema);
+                    done();
+                }, options);
             });
 
             it('should throw an error if the documents do not have the same schema', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = false;
                 converter.json2csv(jsonTestData.differentSchemas, function (err, csv) {
                     err.message.should.equal(constants.Errors.json2csv.notSameSchema);
                     done();
@@ -625,6 +699,39 @@ var json2csvTests = function () {
                     true.should.equal(_.isEqual(err, null));
                     csv.should.equal(csvTestData.quoted.regularJson);
                     csv.split(options.EOL).length.should.equal(6);
+                    done();
+                }, options);
+            });
+
+            it('should parse different schemas when requested', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csv(jsonTestData.differentSchemas, function (err, csv) {
+                    if (err) { throw err; }
+                    true.should.equal(_.isEqual(err, null));
+                    csv.should.equal(csvTestData.quoted.differentSchemas);
+                    csv.split(options.EOL).length.should.equal(6);
+                    done();
+                }, options);
+            });
+
+            it('should parse different schemas (only at nesting level) when requested', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csv(jsonTestData.differentSchemasNested, function (err, csv) {
+                    if (err) { throw err; }
+                    true.should.equal(_.isEqual(err, null));
+                    csv.should.equal(csvTestData.quoted.differentSchemasNested);
+                    csv.split(options.EOL).length.should.equal(7);
+                    done();
+                }, options);
+            });
+
+            it("should parse different schemas that 'upgrade' from a null value to an nested object.", function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csv(jsonTestData.differentSchemasNullUpgrade, function (err, csv) {
+                    if (err) { throw err; }
+                    true.should.equal(_.isEqual(err, null));
+                    csv.should.equal(csvTestData.quoted.differentSchemasNullUpgrade);
+                    csv.split(options.EOL).length.should.equal(4);
                     done();
                 }, options);
             });
@@ -1002,6 +1109,45 @@ var json2csvTests = function () {
                     });
             });
 
+            it('should parse different schemas when requested', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csvAsync(jsonTestData.differentSchemas, options)
+                    .then(function (csv) {
+                        csv.should.equal(csvTestData.unQuoted.differentSchemas);
+                        csv.split(options.EOL).length.should.equal(6);
+                        done();
+                    })
+                    .catch(function (err) {
+                        throw err;
+                    });
+            });
+
+            it('should parse different schemas (only at nesting level) when requested', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csvAsync(jsonTestData.differentSchemasNested, options)
+                    .then(function (csv) {
+                        csv.should.equal(csvTestData.unQuoted.differentSchemasNested);
+                        csv.split(options.EOL).length.should.equal(7);
+                        done();
+                    })
+                    .catch(function (err) {
+                        throw err;
+                    });
+            });
+
+            it("should parse different schemas that 'upgrade' from a null value to an nested object.", function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csvAsync(jsonTestData.differentSchemasNullUpgrade, options)
+                    .then(function (csv) {
+                        csv.should.equal(csvTestData.unQuoted.differentSchemasNullUpgrade);
+                        csv.split(options.EOL).length.should.equal(4);
+                        done();
+                    })
+                    .catch(function (err) {
+                        throw err;
+                    });
+            });
+
             it('should repress the heading', function (done) {
                 opts = JSON.parse(JSON.stringify(options));
                 opts.PREPEND_HEADER = false;
@@ -1167,6 +1313,45 @@ var json2csvTests = function () {
                     .then(function (csv) {
                         csv.should.equal(csvTestData.unQuoted.regularJson.replace(new RegExp(defaultOptions.DELIMITER.FIELD, 'g'), options.DELIMITER.FIELD));
                         csv.split(options.EOL).length.should.equal(6);
+                        done();
+                    })
+                    .catch(function (err) {
+                        throw err;
+                    });
+            });
+
+            it('should parse different schemas when requested', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csvAsync(jsonTestData.differentSchemas, options)
+                    .then(function (csv) {
+                        csv.should.equal(csvTestData.unQuoted.differentSchemas.replace(new RegExp(defaultOptions.DELIMITER.FIELD, 'g'), options.DELIMITER.FIELD));
+                        csv.split(options.EOL).length.should.equal(6);
+                        done();
+                    })
+                    .catch(function (err) {
+                        throw err;
+                    });
+            });
+
+            it('should parse different schemas (only at nesting level) when requested', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csvAsync(jsonTestData.differentSchemasNested, options)
+                    .then(function (csv) {
+                        csv.should.equal(csvTestData.unQuoted.differentSchemasNested.replace(new RegExp(defaultOptions.DELIMITER.FIELD, 'g'), options.DELIMITER.FIELD));
+                        csv.split(options.EOL).length.should.equal(7);
+                        done();
+                    })
+                    .catch(function (err) {
+                        throw err;
+                    });
+            });
+
+            it("should parse different schemas that 'upgrade' from a null value to an nested object.", function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csvAsync(jsonTestData.differentSchemasNullUpgrade, options)
+                    .then(function (csv) {
+                        csv.should.equal(csvTestData.unQuoted.differentSchemasNullUpgrade.replace(new RegExp(defaultOptions.DELIMITER.FIELD, 'g'), options.DELIMITER.FIELD));
+                        csv.split(options.EOL).length.should.equal(4);
                         done();
                     })
                     .catch(function (err) {
@@ -1347,10 +1532,50 @@ var json2csvTests = function () {
             });
 
             it('should parse an array of JSON documents with the same schema but different ordering of fields', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
                 converter.json2csvAsync(jsonTestData.sameSchemaDifferentOrdering, options)
                     .then(function (csv) {
                         csv.should.equal(csvTestData.quoted.regularJson);
                         csv.split(options.EOL).length.should.equal(6);
+                        done();
+                    })
+                    .catch(function (err) {
+                        throw err;
+                    });
+            });
+
+            it('should parse different schemas when requested', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csvAsync(jsonTestData.differentSchemas, options)
+                    .then(function (csv) {
+                        csv.should.equal(csvTestData.quoted.differentSchemas);
+                        csv.split(options.EOL).length.should.equal(6);
+                        done();
+                    })
+                    .catch(function (err) {
+                        throw err;
+                    });
+            });
+
+            it('should parse different schemas (only at nesting level) when requested', function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csvAsync(jsonTestData.differentSchemasNested, options)
+                    .then(function (csv) {
+                        csv.should.equal(csvTestData.quoted.differentSchemasNested);
+                        csv.split(options.EOL).length.should.equal(7);
+                        done();
+                    })
+                    .catch(function (err) {
+                        throw err;
+                    });
+            });
+
+            it("should parse different schemas that 'upgrade' from a null value to an nested object.", function (done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csvAsync(jsonTestData.differentSchemasNullUpgrade, options)
+                    .then(function (csv) {
+                        csv.should.equal(csvTestData.quoted.differentSchemasNullUpgrade);
+                        csv.split(options.EOL).length.should.equal(4);
                         done();
                     })
                     .catch(function (err) {

--- a/test/testJson2Csv.js
+++ b/test/testJson2Csv.js
@@ -96,7 +96,6 @@ var json2csvTests = function () {
                 });
             });
 
-            // simon
             it('should throw an error if the documents do not have the same schema', function (done) {
                 converter.json2csv(jsonTestData.differentSchemas, function (err, csv) {
                     err.message.should.equal(constants.Errors.json2csv.notSameSchema);
@@ -300,6 +299,32 @@ var json2csvTests = function () {
                     done();
                 }, options);
             });
+
+
+            /**
+             * Replace all occurences inside a string, instead of only the first one as str.replace does...
+             * http://stackoverflow.com/a/1144788/619465
+             * @param find
+             * @param replace
+             * @param str
+             * @returns {void|string|XML}
+             */
+            function replaceAll(find, replace, str) {
+                return str.replace(new RegExp(find, 'g'), replace);
+            }
+
+            it("Should parse different schemas, even when the different data types are used for the same field name.", function(done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csv(jsonTestData.differentSchemasFieldTypes, function (err, csv) {
+                    if (err) { throw err; }
+                    true.should.equal(_.isEqual(err, null));
+                    var quoted = csvTestData.quoted.differentSchemasFieldTypes;
+                    var unquoted = replaceAll('"','', quoted);
+                    csv.should.equal(unquoted);
+                    csv.split(options.EOL).length.should.equal(4);
+                    done();
+                }, options);
+            })
 
             it('should repress the heading', function (done) {
                 options.PREPEND_HEADER = false;

--- a/test/testJson2Csv.js
+++ b/test/testJson2Csv.js
@@ -326,6 +326,19 @@ var json2csvTests = function () {
                 }, options);
             })
 
+            it("Should convert false, 0 and null values to their expected value.", function(done) {
+                options.ALLOW_DIFFERENT_SCHEMAS = true;
+                converter.json2csv(jsonTestData.false0null, function (err, csv) {
+                    if (err) { throw err; }
+                    true.should.equal(_.isEqual(err, null));
+                    var quoted = csvTestData.quoted.false0null;
+                    var unquoted = replaceAll('"','', quoted);
+                    csv.should.equal(unquoted);
+                    csv.split(options.EOL).length.should.equal(3);
+                    done();
+                }, options);
+            })
+
             it('should repress the heading', function (done) {
                 options.PREPEND_HEADER = false;
 

--- a/test/testJsonFilesList.js
+++ b/test/testJsonFilesList.js
@@ -13,5 +13,6 @@ module.exports = {
     differentSchemas: require('./JSON/differentSchemas'),
     differentSchemasFieldTypes: require('./JSON/differentSchemasFieldTypes.json'),
     differentSchemasNested: require('./JSON/differentSchemasNested'),
-    differentSchemasNullUpgrade: require('./JSON/differentSchemasNullUpgrade')
+    differentSchemasNullUpgrade: require('./JSON/differentSchemasNullUpgrade'),
+    false0null: require('./JSON/false0null.json')
 };

--- a/test/testJsonFilesList.js
+++ b/test/testJsonFilesList.js
@@ -10,5 +10,7 @@ module.exports = {
     regularJson: require('./JSON/regularJson'),
     singleDoc: require('./JSON/singleDoc'),
     sameSchemaDifferentOrdering: require('./JSON/sameSchemaDifferentOrdering'),
-    differentSchemas: require('./JSON/differentSchemas')
+    differentSchemas: require('./JSON/differentSchemas'),
+    differentSchemasNested: require('./JSON/differentSchemasNested'),
+    differentSchemasNullUpgrade: require('./JSON/differentSchemasNullUpgrade')
 };

--- a/test/testJsonFilesList.js
+++ b/test/testJsonFilesList.js
@@ -11,6 +11,7 @@ module.exports = {
     singleDoc: require('./JSON/singleDoc'),
     sameSchemaDifferentOrdering: require('./JSON/sameSchemaDifferentOrdering'),
     differentSchemas: require('./JSON/differentSchemas'),
+    differentSchemasFieldTypes: require('./JSON/differentSchemasFieldTypes.json'),
     differentSchemasNested: require('./JSON/differentSchemasNested'),
     differentSchemasNullUpgrade: require('./JSON/differentSchemasNullUpgrade')
 };

--- a/test/testSchemaCombiner.js
+++ b/test/testSchemaCombiner.js
@@ -1,0 +1,244 @@
+var _ = require('underscore');
+var should = require('should');
+var assert = require('assert');
+var schemaCombiner = require('../lib/schema-combiner');
+
+describe('schema-combiner Module', function () {
+    it('should combine two equal objects', function(done) {
+        var object1 = {
+            field1: 25,
+            field2: 27,
+            field3: null
+        };
+
+        var object2 = {
+            field1: 29,
+            field2: 52,
+            field3: null
+        };
+
+        var result = schemaCombiner.buildCombinedDocumentSchema([object1, object2]);
+        var expectedResult = {
+            totals: {
+                uniqueFieldCount: 3,
+                fieldCount: 6,
+            },
+            fields: {
+                field1: {
+                    primitives: {
+                        emptyCount: 0,
+                        filledCount: 2
+                    },
+                    objects: {
+                        count: 0,
+                        fields: {}
+                    }
+                },
+                field2: {
+                    primitives: {
+                        emptyCount: 0,
+                        filledCount: 2
+                    },
+                    objects: {
+                        count: 0,
+                        fields: {}
+                    }
+                },
+                field3: {
+                    primitives: {
+                        emptyCount: 2,
+                        filledCount: 0
+                    },
+                    objects: {
+                        count: 0,
+                        fields: {}
+                    }
+                }
+            }
+        }
+
+        assert.deepEqual(result, expectedResult);
+        done();
+    });
+
+    it('should count fields in subdocuments', function(done) {
+        var object1 = {
+            field1: {
+                field2: 3,
+            }
+        }
+
+        var object2 = {
+            field1: {}
+        }
+
+        var result = schemaCombiner.buildCombinedDocumentSchema([object1, object2]);
+        var expectedResult = {
+            totals: {
+                uniqueFieldCount: 2,
+                fieldCount: 3
+            },
+            fields: {
+                field1: {
+                    primitives: {
+                        emptyCount:0,
+                        filledCount:0
+                    },
+                    objects: {
+                        count: 2,
+                        fields: {
+                            field2: {
+                                primitives: {
+                                    emptyCount: 0,   // It's non existing. It's not declared so it's not counted!   We might need to split so that we also can see if we may stringify it to a boolean i.e.
+                                    filledCount: 1
+                                },
+                                objects: {
+                                    count: 0,
+                                    fields: {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        assert.deepEqual(result, expectedResult);
+        done();
+    });
+
+    it('should count fields that have both subfields and values', function(done) {
+        var object1 = {
+            field: {
+                subfield: 3
+            }
+        }
+
+        var object2 = {
+            field: 24
+        }
+
+        var object3 = {
+            field: null
+        }
+
+        var object4 = {
+            field: undefined
+        }
+
+        var result = schemaCombiner.buildCombinedDocumentSchema([object1, object2, object3, object4]);
+        var expectedResult = {
+            totals: {
+                uniqueFieldCount: 2,
+                fieldCount: 5
+            },
+            fields: {
+                field: {
+                    primitives: {
+                        emptyCount:2, // null and undefined shall both be counted as empty!
+                        filledCount:1
+                    },
+                    objects: {
+                        count: 1,
+                        fields: {
+                            subfield: {
+                                primitives: {
+                                    emptyCount: 0,
+                                    filledCount: 1
+                                },
+                                objects: {
+                                    count: 0,
+                                    fields: {}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        assert.deepEqual(result, expectedResult);
+        done();
+    });
+
+
+    it('should work recursive', function(done) {
+        var object1 = {
+            level1: {
+                level2: {
+                    level3: {
+                        value: 10
+                    }
+                }
+            }
+        }
+
+        var object2 = {
+            level1: {
+                level2: {
+                    level3: {
+                        value: 11
+                    }
+                }
+            }
+        }
+
+        var result = schemaCombiner.buildCombinedDocumentSchema([object1, object2]);
+        var expectedResult = {
+            totals: {
+                uniqueFieldCount: 4,
+                fieldCount: 8
+            },
+            fields: {
+                level1: {
+                    primitives: {
+                        emptyCount:0,
+                        filledCount:0
+                    },
+                    objects: {
+                        count: 2,
+                        fields: {
+                            level2: {
+                                primitives: {
+                                    emptyCount:0,
+                                    filledCount:0
+                                },
+                                objects: {
+                                    count: 2,
+                                    fields: {
+                                        level3: {
+                                            primitives: {
+                                                emptyCount:0,
+                                                filledCount:0
+                                            },
+                                            objects: {
+                                                count: 2,
+                                                fields: {
+                                                    value: {
+                                                        primitives: {
+                                                            emptyCount:0,
+                                                            filledCount:2
+                                                        },
+                                                        objects: {
+                                                            count: 0,
+                                                            fields: {
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        assert.deepEqual(result, expectedResult);
+        done();
+    });
+
+});


### PR DESCRIPTION
I had the same problem is described in [this thread](https://github.com/mrodrig/json-2-csv/issues/12#issuecomment-110341395), it was a bit difficult in my situation to make all document schemas equal so I thought that it would be usefull to just add the different schema support. I had to make more changes then I though, but all tests (including the new one) are green now.

I added a seperate schema-combiner module that merges different schemas together.

The default is still that schema differences are not accepted. I added an option that people can enable to make this work.

Looking forward to your feedback on this!

Best regards,
Simon Koudijs
Intellifi
