### PR TITLE
Fixing trimming of fields in json2csv

### DIFF
--- a/lib/json-2-csv.js
+++ b/lib/json-2-csv.js
@@ -113,9 +113,6 @@ convertData = function (data, keys) {
  * @param output
  */
 var convertField = function (value) {
-    // if the user wants to trim field values
-    value = options.TRIM_FIELD_VALUES ? value.trim() : value;
-
     if (_.isArray(value)) { // We have an array of values
         var result = [];
         value.forEach(function(item) {
@@ -123,20 +120,28 @@ var convertField = function (value) {
                 // use JSON stringify to convert objects in arrays, otherwise toString() will just return [object Object]
                 result.push(JSON.stringify(item));
             } else {
-                result.push(item);
+                result.push(convertValue(item));
             }
         });
         return options.DELIMITER.WRAP + '[' + result.join(options.DELIMITER.ARRAY) + ']' + options.DELIMITER.WRAP;
     } else if (_.isDate(value)) { // If we have a date
-        return options.DELIMITER.WRAP + value.toString() + options.DELIMITER.WRAP;
+        return options.DELIMITER.WRAP + convertValue(value) + options.DELIMITER.WRAP;
     } else if (_.isObject(value)) { // If we have an object
         return options.DELIMITER.WRAP + convertData(value, _.keys(value)) + options.DELIMITER.WRAP; // Push the recursively generated CSV
     } else if (_.isNumber(value)) { // If we have a number (avoids 0 being converted to '')
-        return options.DELIMITER.WRAP + value.toString() + options.DELIMITER.WRAP;
+        return options.DELIMITER.WRAP + convertValue(value) + options.DELIMITER.WRAP;
     } else if (_.isBoolean(value)) { // If we have a boolean (avoids false being converted to '')
-        return options.DELIMITER.WRAP + value.toString() + options.DELIMITER.WRAP;
+        return options.DELIMITER.WRAP + convertValue(value) + options.DELIMITER.WRAP;
     }
-    return options.DELIMITER.WRAP + (value ? value.toString() : '') + options.DELIMITER.WRAP; // Otherwise push the current value
+    return options.DELIMITER.WRAP + convertValue(value) + options.DELIMITER.WRAP; // Otherwise push the current value
+};
+
+var convertValue = function (val) {
+    // Convert to string
+    val = _.isNull(val) || _.isUndefined(val) ? '' : val.toString();
+    
+    // Trim, if necessary, and return the correct value
+    return options.TRIM_FIELD_VALUES ? val.trim() : val;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "author": "mrodrig",
     "name": "json-2-csv",
     "description": "A JSON to CSV and CSV to JSON converter that natively supports sub-documents and auto-generates the CSV heading.",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "repository": {
         "type": "git",
         "url": "http://github.com/mrodrig/json-2-csv.git"


### PR DESCRIPTION
While working on updating documentation, I noticed a bug in the json2csv field trimming functionality.