### PR TITLE
Attempting to fix a few issues and an edge case bug I found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ json2csv(array, callback, options)
     * `array` - String - Array Value Delimiter. 
       * Default: `';'`
     * `wrap` - String - Wrap values in the delimiter of choice (e.g. wrap values in quotes). 
-      * Default: `''`
+      * Default: `'"'`
     * `eol` - String - End of Line Delimiter. 
       * Default: `'\n'`
   * `prependHeader` - Boolean - Should the auto-generated header be prepended as the first line in the CSV?
@@ -80,7 +80,7 @@ csv2json(csv, callback, options)
     * `array` - String - Array Value Delimiter. 
       * Default: `';'`
     * `wrap` - String - The character that field values are wrapped in. 
-      * Default: `''`
+      * Default: `'"'`
     * `eol` - String - End of Line Delimiter. 
       * Default: `'\n'`
   * `trimHeaderValues` - Boolean - Should the header fields be trimmed? 

--- a/lib/constants.json
+++ b/lib/constants.json
@@ -23,7 +23,7 @@
     "DELIMITER" : {
       "FIELD" : ",",
       "ARRAY" : ";",
-      "WRAP"  : "",
+      "WRAP"  : "\"",
       "EOL"   : "\n"
     },
     "PREPEND_HEADER" : true,

--- a/lib/json-2-csv.js
+++ b/lib/json-2-csv.js
@@ -101,7 +101,7 @@ convertData = function (data, keys) {
     return _.reduce(keys, function (output, key) {
         // Retrieve the appropriate field data
         var fieldData = path.evaluatePath(data, key);
-        if (_.isUndefined(fieldData)) { fieldData = options.EMPTY_FIELD_VALUE; }
+        if (_.isUndefined(fieldData) || fieldData == '' || fieldData == null) { fieldData = options.EMPTY_FIELD_VALUE; }
         // Add the CSV representation of the data at the key in the document to the output array
         return output.concat(convertField(fieldData));
     }, []);
@@ -139,6 +139,10 @@ var convertField = function (value) {
 var convertValue = function (val) {
     // Convert to string
     val = _.isNull(val) || _.isUndefined(val) ? '' : val.toString();
+
+    if(options.DELIMITER.WRAP == '"') {
+        val = val.replace(/"/g, '""');
+    }
     
     // Trim, if necessary, and return the correct value
     return options.TRIM_FIELD_VALUES ? val.trim() : val;


### PR DESCRIPTION
1. Added in default wrap delimiter of double quotes. Also updated README (#55)
2. Fixed issue #61 by using EMPTY_FIELD_VALUE in the proper cases.
3. Fixed scenario where there's double quotes in a field value, by doubling up the double quotes -- per RFC-4180.

IMPORTANT:
1. I did NOT manage to test csv2json.
2. Wiki would need updated still regarding #55.
3. Mocha tests seemed to fail for me, but all practical cases of using it have worked that I've found.
4. I'm only escaping double quotes right now -- I'm not sure how other field wrap delimiters would need to be wrapped.
