### PR TITLE
 Escape nested quote with an additional quote

### DIFF
--- a/lib/csv-2-json.js
+++ b/lib/csv-2-json.js
@@ -175,9 +175,8 @@ var splitLine = function (line) {
             stateVariables.parsingValue = true;
             stateVariables.startIndex = index + 1;
         }
-        else if (character === "\\" && charAfter === options.DELIMITER.WRAP && stateVariables.insideWrapDelimiter) {
+        else if (character === options.DELIMITER.WRAP && charAfter === options.DELIMITER.WRAP && stateVariables.insideWrapDelimiter) {
             line = line.slice(0, index) + line.slice(index+1); // Remove the current character from the line
-            index--; // Move to position before to prevent moving ahead and skipping a character
             lastCharacterIndex--; // Update the value since we removed a character
         }
         // Otherwise increment to the next character

--- a/lib/json-2-csv.js
+++ b/lib/json-2-csv.js
@@ -133,7 +133,7 @@ var convertField = function (value) {
     } else if (_.isBoolean(value)) { // If we have a boolean (avoids false being converted to '')
         return options.DELIMITER.WRAP + convertValue(value) + options.DELIMITER.WRAP;
     }
-    value = options.DELIMITER.WRAP && value ? value.replace(new RegExp(options.DELIMITER.WRAP, 'g'), "\\"+options.DELIMITER.WRAP) : value;
+    value = options.DELIMITER.WRAP && value ? value.replace(new RegExp(options.DELIMITER.WRAP, 'g'), options.DELIMITER.WRAP + options.DELIMITER.WRAP) : value;
     return options.DELIMITER.WRAP + convertValue(value) + options.DELIMITER.WRAP; // Otherwise push the current value
 };
 

--- a/test/CSV/quoted/nestedQuotes.csv
+++ b/test/CSV/quoted/nestedQuotes.csv
@@ -1,3 +1,4 @@
 "a string"
 "with a description"
 "with a description and ""quotes"""
+"with a description and multiple """"""quotes"""""""

--- a/test/CSV/quoted/nestedQuotes.csv
+++ b/test/CSV/quoted/nestedQuotes.csv
@@ -1,3 +1,3 @@
 "a string"
 "with a description"
-"with a description and \"quotes\""
+"with a description and ""quotes"""

--- a/test/CSV/unQuoted/nestedQuotes.csv
+++ b/test/CSV/unQuoted/nestedQuotes.csv
@@ -1,3 +1,4 @@
 a string
 with a description
 with a description and "quotes"
+with a description and multiple """quotes"""

--- a/test/JSON/nestedQuotes.json
+++ b/test/JSON/nestedQuotes.json
@@ -1,4 +1,5 @@
 [
   {"a string": "with a description"},
-  {"a string": "with a description and \"quotes\""}
+  {"a string": "with a description and \"quotes\""},
+  {"a string": "with a description and multiple \"\"\"quotes\"\"\""}
 ]

--- a/test/testCsv2Json.js
+++ b/test/testCsv2Json.js
@@ -328,7 +328,7 @@ var csv2jsonTests = function () {
                     if (err) { throw err; }
                     true.should.equal(_.isEqual(err, null));
                     csv.should.equal(csvTestData.unQuoted.nestedQuotes.replace(/,/g, options.DELIMITER.FIELD));
-                    csv.split(options.DELIMITER.EOL).length.should.equal(4);
+                    csv.split(options.DELIMITER.EOL).length.should.equal(5);
                     done();
                 }, options);
             });

--- a/test/testJson2Csv.js
+++ b/test/testJson2Csv.js
@@ -51,7 +51,7 @@ var json2csvTests = function () {
                     if (err) { throw err; }
                     true.should.equal(_.isEqual(err, null));
                     csv.should.equal(csvTestData.unQuoted.nestedQuotes);
-                    csv.split(options.DELIMITER.EOL).length.should.equal(4);
+                    csv.split(options.DELIMITER.EOL).length.should.equal(5);
                     done();
                 });
             });
@@ -210,7 +210,7 @@ var json2csvTests = function () {
                     if (err) { throw err; }
                     true.should.equal(_.isEqual(err, null));
                     csv.should.equal(csvTestData.unQuoted.nestedQuotes);
-                    csv.split(options.DELIMITER.EOL).length.should.equal(4);
+                    csv.split(options.DELIMITER.EOL).length.should.equal(5);
                     done();
                 }, options);
             });
@@ -385,7 +385,7 @@ var json2csvTests = function () {
                     if (err) { throw err; }
                     true.should.equal(_.isEqual(err, null));
                     csv.should.equal(csvTestData.unQuoted.nestedQuotes.replace(new RegExp(defaultOptions.DELIMITER.FIELD, 'g'), options.DELIMITER.FIELD));
-                    csv.split(options.DELIMITER.EOL).length.should.equal(4);
+                    csv.split(options.DELIMITER.EOL).length.should.equal(5);
                     done();
                 }, options);
             });
@@ -562,7 +562,7 @@ var json2csvTests = function () {
                     if (err) { throw err; }
                     true.should.equal(_.isEqual(err, null));
                     csv.should.equal(csvTestData.quoted.nestedQuotes.replace(/,/g, options.DELIMITER.FIELD));
-                    csv.split(options.DELIMITER.EOL).length.should.equal(4);
+                    csv.split(options.DELIMITER.EOL).length.should.equal(5);
                     done();
                 }, options);
             });
@@ -882,7 +882,7 @@ var json2csvTests = function () {
                 converter.json2csvPromisified(jsonTestData.nestedQuotes)
                     .then(function(csv) {
                         csv.should.equal(csvTestData.unQuoted.nestedQuotes);
-                        csv.split(options.DELIMITER.EOL).length.should.equal(4);
+                        csv.split(options.DELIMITER.EOL).length.should.equal(5);
                         done();
                     })
                     .catch(function (err) {
@@ -1024,7 +1024,7 @@ var json2csvTests = function () {
                 converter.json2csvPromisified(jsonTestData.nestedQuotes, options)
                     .then(function(csv) {
                         csv.should.equal(csvTestData.unQuoted.nestedQuotes);
-                        csv.split(options.DELIMITER.EOL).length.should.equal(4);
+                        csv.split(options.DELIMITER.EOL).length.should.equal(5);
                         done();
                     })
                     .catch(function (err) {
@@ -1195,7 +1195,7 @@ var json2csvTests = function () {
                 converter.json2csvPromisified(jsonTestData.nestedQuotes, options)
                     .then(function(csv) {
                         csv.should.equal(csvTestData.unQuoted.nestedQuotes.replace(new RegExp(defaultOptions.DELIMITER.FIELD, 'g'), options.DELIMITER.FIELD));
-                        csv.split(options.DELIMITER.EOL).length.should.equal(4);
+                        csv.split(options.DELIMITER.EOL).length.should.equal(5);
                         done();
                     })
                     .catch(function (err) {
@@ -1368,7 +1368,7 @@ var json2csvTests = function () {
                 converter.json2csvPromisified(jsonTestData.nestedQuotes, options)
                     .then(function(csv) {
                         csv.should.equal(csvTestData.quoted.nestedQuotes.replace(/,/g, options.DELIMITER.FIELD));
-                        csv.split(options.DELIMITER.EOL).length.should.equal(4);
+                        csv.split(options.DELIMITER.EOL).length.should.equal(5);
                         done();
                     })
                     .catch(function (err) {


### PR DESCRIPTION
According to [RFC 4180](https://tools.ietf.org/html/rfc4180) the proper way to escape double-quotes in CSV data is to prepend an additional double-quote character:

> If double-quotes are used to enclose fields, then a double-quote appearing inside a field must be escaped by preceding it with another double quote.

Currently we escape double-quotes using a backslash. Opening a file witch such content in Microsoft Excel and/or Apple Numbers breaks the column layout, i.e. the value containing the double quote is interpretted as multiple columns instead of one. On the contrary, escaping using an extra double-quote preserves the expected column layout in both Microsoft Excel and Apple Numbers.