### PR TITLE
fix: Remove console.log from isEmptyField-function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -135,6 +135,5 @@ function computeSchemaDifferences(schemaA, schemaB) {
  * @returns {boolean}
  */
 function isEmptyField(fieldValue) {
-    console.log(fieldValue);
     return _.isUndefined(fieldValue) || _.isNull(fieldValue) || fieldValue === '';
 }


### PR DESCRIPTION
emptyFieldValue is reintroduced in #98, however there was still an console.log in the source that logs all values to the console.

(I didn't add a test, however you may want to add the `no-console` rule to the linter).

## Background Information

- Fixes issue(s): #97
- Proposed release version:

I have...
- [ ] added at least one test to verify the failure condition is fixed.
- [x] verified the tests are passing.

<!-- Thanks for your pull request! -->