### PR TITLE
Update badge URL to use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 **Convert JSON to CSV _or_ CSV to JSON**
 
 [![Dependencies](https://img.shields.io/david/mrodrig/json-2-csv.svg)](https://www.npmjs.org/package/json-2-csv)
-[![Downloads](http://img.shields.io/npm/dm/json-2-csv.svg)](https://www.npmjs.org/package/json-2-csv)
+[![Downloads](https://img.shields.io/npm/dm/json-2-csv.svg)](https://www.npmjs.org/package/json-2-csv)
 [![NPM version](https://img.shields.io/npm/v/json-2-csv.svg)](https://www.npmjs.org/package/json-2-csv)
 [![Minzipped Size](https://flat.badgen.net/bundlephobia/minzip/json-2-csv)](https://bundlephobia.com/result?p=json-2-csv)
 [![Package Size](https://img.shields.io/bundlephobia/min/json-2-csv.svg)](https://www.npmjs.org/package/json-2-csv)


### PR DESCRIPTION
Using http causes a mixed content warning in Chrome. This also makes the NPM page have a`Not Secure` status next to the address bar.

![image](https://user-images.githubusercontent.com/5500199/77949553-c1c32100-728c-11ea-862c-3185412862ac.png)
