### PR TITLE
Fix TS options definition to include unwindArrays, useLocaleFormat

### DIFF
--- a/src/converter.d.ts
+++ b/src/converter.d.ts
@@ -17,6 +17,7 @@ export interface ISharedOptions {
    *  @default false
    */
   excelBOM?: boolean;
+
   /**
    * Specify the keys (as strings) that should be converted
    *
@@ -24,11 +25,13 @@ export interface ISharedOptions {
    * * If you want all keys to be converted, then specify null or don't specify the option to utilize the default.
    */
   keys?: string[];
+
   /**
    * Should the header fields be trimmed
    * @default false
    */
   trimHeaderFields?: boolean;
+
   /**
    * Should the field values be trimmed? (in development)
    * @default false
@@ -60,11 +63,24 @@ export interface IFullOptions extends ISharedOptions {
    * @default true
    */
   prependHeader?: boolean;
+
   /**
    * Should the header keys be sorted in alphabetical order
    * @default false
    */
   sortHeader?: boolean;
+
+  /**
+   * Should array values be "unwound" such that there is one line per value in the array?
+   * @default false
+   */
+  unwindArrays?: boolean;
+
+  /**
+   * Should values be converted to a locale specific string?
+   * @default false
+   */
+  useLocaleFormat?: boolean;
 
 }
 


### PR DESCRIPTION
As was pointed out in #158, the unwindArrays option was missing from the TypeScript definitions. After further investigation, it was also found that useLocaleFormat was missing. Both options were added to the TypeScript options definitions in this commit.

Fixes #158

## Background Information

- Fixes issue(s): #158 
- Proposed release version: `3.7.6`

I have...
- [x] verified the tests are passing.

<!-- Thanks for your pull request! -->