### PR TITLE
Flatten support for >200k row arrays

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,8 +3,8 @@
 let path = require('doc-path'),
     constants = require('./constants.json');
 
-const dateStringRegex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
-const MAX_ARRAY_LENGTH = 100000
+const dateStringRegex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/,
+    MAX_ARRAY_LENGTH = 100000;
 
 module.exports = {
     isStringRepresentation,
@@ -287,11 +287,11 @@ function unique(array) {
 
 function flatten(array) {
     if (array.length > MAX_ARRAY_LENGTH) {
-        let safeArray = []
+        let safeArray = [];
         for (let a = 0; a < array.length; a += MAX_ARRAY_LENGTH) {
-            safeArray = safeArray.concat(...array.slice(a, a + MAX_ARRAY_LENGTH))
+            safeArray = safeArray.concat(...array.slice(a, a + MAX_ARRAY_LENGTH));
         }
-        return safeArray
+        return safeArray;
     }
     return [].concat(...array);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ let path = require('doc-path'),
     constants = require('./constants.json');
 
 const dateStringRegex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
+const MAX_ARRAY_LENGTH = 100000
 
 module.exports = {
     isStringRepresentation,
@@ -285,6 +286,13 @@ function unique(array) {
 }
 
 function flatten(array) {
+    if (array.length > MAX_ARRAY_LENGTH) {
+        let safeArray = []
+        for (let a = 0; a < array.length; a += MAX_ARRAY_LENGTH) {
+            safeArray = safeArray.concat(...array.slice(a, a + MAX_ARRAY_LENGTH))
+        }
+        return safeArray
+    }
     return [].concat(...array);
 }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,5 +1,6 @@
 let json2csvTests = require('./json2csv'),
     csv2jsonTests = require('./csv2json'),
+    utilsTests = require('./utilsTests'),
     jsonTestData = require('./config/testJsonFilesList'),
     csvTestData = require('./config/testCsvFilesList');
 
@@ -10,4 +11,7 @@ describe('json-2-csv Node Module', function() {
 
     // Run CSV to JSON Tests
     csv2jsonTests.runTests(jsonTestData, csvTestData);
+
+    // Run Utils Tests
+    utilsTests.runTests();
 });

--- a/test/utilsTests.js
+++ b/test/utilsTests.js
@@ -1,0 +1,36 @@
+'use strict';
+
+/* eslint no-unused-vars: ["error", { "varsIgnorePattern": "should" }]*/
+
+let should = require('should'),
+    converter = require('../src/converter'),
+    constants = require('../src/constants'),
+    utils = require('../src/utils'),
+    defaultOptions = constants.defaultOptions;
+
+function runTests() {
+    describe('utils', () => {
+        describe('flatten()', () => {
+            it('should flatten a nested array', (done) => {
+                const nested = [[1],[2],[3],[4],[5]]
+                const expected = [1,2,3,4,5]
+                const result = utils.flatten(nested)
+                result.should.deepEqual(expected)
+                done()
+            });
+            it('should handle extremely large arrays', (done) => {
+                const nested = []
+                const expected = []
+                for (let a = 0; a < 234567; a++) {
+                    nested.push([a])
+                    expected.push(a)
+                }
+                const result = utils.flatten(nested)
+                result.should.deepEqual(expected)
+                done()
+            });
+        });
+    });
+}
+
+module.exports = { runTests };

--- a/test/utilsTests.js
+++ b/test/utilsTests.js
@@ -3,31 +3,31 @@
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "should" }]*/
 
 let should = require('should'),
-    converter = require('../src/converter'),
-    constants = require('../src/constants'),
-    utils = require('../src/utils'),
-    defaultOptions = constants.defaultOptions;
+    utils = require('../src/utils');
 
 function runTests() {
     describe('utils', () => {
         describe('flatten()', () => {
             it('should flatten a nested array', (done) => {
-                const nested = [[1],[2],[3],[4],[5]]
-                const expected = [1,2,3,4,5]
-                const result = utils.flatten(nested)
-                result.should.deepEqual(expected)
+                const nested = [[1], [2], [3], [4], [5]],
+                    expected = [1, 2, 3, 4, 5],
+                    result = utils.flatten(nested);
+
+                result.should.deepEqual(expected);
                 done()
             });
+
             it('should handle extremely large arrays', (done) => {
-                const nested = []
-                const expected = []
+                const nested = [],
+                    expected = [];
                 for (let a = 0; a < 234567; a++) {
-                    nested.push([a])
-                    expected.push(a)
+                    nested.push([a]);
+                    expected.push(a);
                 }
-                const result = utils.flatten(nested)
-                result.should.deepEqual(expected)
-                done()
+
+                const result = utils.flatten(nested);
+                result.should.deepEqual(expected);
+                done();
             });
         });
     });

--- a/test/utilsTests.js
+++ b/test/utilsTests.js
@@ -14,7 +14,7 @@ function runTests() {
                     result = utils.flatten(nested);
 
                 result.should.deepEqual(expected);
-                done()
+                done();
             });
 
             it('should handle extremely large arrays', (done) => {


### PR DESCRIPTION
## Background Information

Attempting to call `utils.flatten` on an array with >200k rows results in a `RangeError: Maximum call stack size exceeded` exception in Chrome. I've fixed this by splitting the concat calls into batches of 100000 if the array is over 100000 rows.

- Fixes issue(s): #167 
- Proposed release version: `3.7.9`

I have...
- [x] added at least one test to verify the failure condition is fixed.
- [x] verified the tests are passing.
