### PR TITLE
Validate field titles against Object.keys list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ env:
     - CC_TEST_REPORTER_ID=90382d7264499c819f742709fe7cb4b2d2a49cc90fd98a9c8414426ac4860e62
 language: node_js
 node_js:
+  - "16"
   - "15"
   - "14"
   - "12"
-  - "10"
 sudo: false
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -143,9 +143,12 @@ const Json2Csv = function(options) {
      * @returns {*}
      */
     function generateCsvHeader(params) {
+        // #185 - generate a keys list to avoid finding native Map() methods
+        let fieldTitleMapKeys = Object.keys(options.fieldTitleMap);
+
         params.header = params.headerFields
             .map(function(field) {
-                const headerKey = options.fieldTitleMap[field] ? options.fieldTitleMap[field] : field;
+                const headerKey = fieldTitleMapKeys.includes(field) ? options.fieldTitleMap[field] : field;
                 return wrapFieldValueIfNecessary(headerKey);
             })
             .join(options.delimiter.field);

--- a/test/config/testCsvFilesList.js
+++ b/test/config/testCsvFilesList.js
@@ -39,7 +39,8 @@ const fs = require('fs'),
         {key: 'firstColumnWrapCRLF', file: '../data/csv/firstColumnWrapCRLF.csv'},
         {key: 'emptyLastFieldValue', file: '../data/csv/emptyLastFieldValue.csv'},
         {key: 'emptyLastFieldValueNoEol', file: '../data/csv/emptyLastFieldValueNoEol.csv'},
-        {key: 'lastCharFieldDelimiter', file: '../data/csv/lastCharFieldDelimiter.csv'}
+        {key: 'lastCharFieldDelimiter', file: '../data/csv/lastCharFieldDelimiter.csv'},
+        {key: 'nativeMapMethod', file: '../data/csv/nativeMapMethod.csv'}
     ];
 
 function readCsvFile(filePath) {

--- a/test/config/testJsonFilesList.js
+++ b/test/config/testJsonFilesList.js
@@ -29,5 +29,6 @@ module.exports = {
     invalidParsedValues: require('../data/json/invalidParsedValues'),
     firstColumnWrapCRLF: require('../data/json/firstColumnWrapCRLF.json'),
     emptyLastFieldValue: require('../data/json/emptyLastFieldValue.json'),
-    emptyLastFieldValueNoEol: require('../data/json/emptyLastFieldValueNoEol.json')
+    emptyLastFieldValueNoEol: require('../data/json/emptyLastFieldValueNoEol.json'),
+    nativeMapMethod: require('../data/json/nativeMapMethod.json')
 };

--- a/test/data/csv/nativeMapMethod.csv
+++ b/test/data/csv/nativeMapMethod.csv
@@ -1,0 +1,2 @@
+set,otherfieldname
+test,test2

--- a/test/data/json/nativeMapMethod.json
+++ b/test/data/json/nativeMapMethod.json
@@ -1,0 +1,6 @@
+[
+    {
+        "set": "test",
+        "otherfieldname": "test2"
+    }
+]

--- a/test/json2csv.js
+++ b/test/json2csv.js
@@ -137,6 +137,14 @@ function runTests(jsonTestData, csvTestData) {
                     done();
                 });
             });
+
+            it('should properly handle headers with the same name as native Map methods', (done) => {
+                converter.json2csv(jsonTestData.nativeMapMethod, (err, csv) => {
+                    if (err) done(err);
+                    csv.should.equal(csvTestData.nativeMapMethod);
+                    done();
+                });
+            });
         });
 
         describe('Error Handling', () => {


### PR DESCRIPTION
As reported in #185, there was a bug where header values could not have
the same name as a Map method. This is because the code was naively
checking for the existence of a possible title field by simply accessing
the raw value of the Map. This resulted in Map.prototype.set being
returned when the "set" JSON key name was used. The logic has been
updated to check for header titles against an Object.keys list now since
that will not include prototype methods for the underlying Map object.

Fixes #185

## Background Information

- Fixes issue(s): #185 
- Proposed release version: `3.12.0`