### PR TITLE
Update doc-path to fix negative lookbehind regexp.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "json-2-csv",
-    "version": "3.14.0",
+    "version": "3.14.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -969,9 +969,9 @@
             "dev": true
         },
         "doc-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-3.0.0.tgz",
-            "integrity": "sha512-fafPInMvgvUfJ50OmoXOTHTfSiLKd7VgLh2CkLxfB56tVSPi6m+9VytjYtfqw+oM/2MNYaZM7FrNBvG6e0AHQg=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-3.0.1.tgz",
+            "integrity": "sha512-Z7yrgf71bNXFK7dHqanaJO6QOkDsIemcxQqEyhIVY/Jfcwm8mMmCHV/w7UZyr9NzTFFbo698TFiLc5exfHNvog=="
         },
         "doctrine": {
             "version": "3.0.0",
@@ -1411,9 +1411,9 @@
             }
         },
         "glob-parent": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-            "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
             "requires": {
                 "is-glob": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     ],
     "dependencies": {
         "deeks": "2.4.1",
-        "doc-path": "3.0.0"
+        "doc-path": "3.0.1"
     },
     "devDependencies": {
         "babel-eslint": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     },
     "name": "json-2-csv",
     "description": "A JSON to CSV and CSV to JSON converter that natively supports sub-documents and auto-generates the CSV heading.",
-    "version": "3.14.0",
+    "version": "3.14.1",
     "homepage": "https://mrodrig.github.io/json-2-csv",
     "repository": {
         "type": "git",


### PR DESCRIPTION
As reported in #197, there was a compatibility issue introduced in
doc-path@3.0.0 where a negative lookbehind Regexp was being used despite
not being supported by many browsers. This caused runtime errors when
this library's functionality was called due to the underlying dependency
compatibility issue. This commit bumps the version to 3.0.1 which fixes
the compatibility issue in the doc-path module.

Fixes #197

## Background Information

- Fixes issue(s): #197
- Proposed release version: `3.14.1`

I have...
- [x] verified the tests are passing.

<!-- Thanks for your pull request! -->