### PR TITLE
Prevent CSV Injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Looking for examples? Check out the Wiki: [json-2-csv Wiki](https://github.com/m
     * Note: If selected, values will be converted using `toLocaleString()` rather than `toString()`
   * `wrapBooleans` - Boolean - Should boolean values be wrapped in wrap delimiters to prevent Excel from converting them to Excel's TRUE/FALSE Boolean values.
     * Default: `false`
+  * `preventCsvInjection` - Boolean - Should CSV injection be prevented by left trimming these characters: Equals (=), Plus (+), Minus (-), At (@), Tab (0x09), Carriage return (0x0D).
+    * Default: `false`
 
 
 For examples, please refer to the [json2csv API Documentation (Link)](https://github.com/mrodrig/json-2-csv/wiki/json2csv-Documentation)

--- a/lib/constants.json
+++ b/lib/constants.json
@@ -36,7 +36,8 @@
     "useDateIso8601Format": false,
     "useLocaleFormat": false,
     "parseValue": null,
-    "wrapBooleans": false
+    "wrapBooleans": false,
+    "preventCsvInjection": false
   },
 
   "values" : {

--- a/lib/converter.d.ts
+++ b/lib/converter.d.ts
@@ -48,11 +48,11 @@ export interface ISharedOptions {
    */
   trimFieldValues?: boolean;
 
-    /**
+  /**
    * Should CSV injection be prevented by left trimming these characters:
    * Equals (=), Plus (+), Minus (-), At (@), Tab (0x09), Carriage return (0x0D).
    * @default false
-  */
+   */
   preventCsvInjection?: boolean;
 }
 

--- a/lib/converter.d.ts
+++ b/lib/converter.d.ts
@@ -47,6 +47,13 @@ export interface ISharedOptions {
    * @default false
    */
   trimFieldValues?: boolean;
+
+    /**
+   * Should CSV injection be prevented by left trimming these characters:
+   * Equals (=), Plus (+), Minus (-), At (@), Tab (0x09), Carriage return (0x0D).
+   * @default false
+  */
+  preventCsvInjection?: boolean;
 }
 
 export interface IFullOptions extends ISharedOptions {

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -252,6 +252,7 @@ const Json2Csv = function(options) {
                 processedRecordData = recordFieldData.map((fieldValue) => {
                     fieldValue = trimRecordFieldValue(fieldValue);
                     fieldValue = valueParserFn(fieldValue);
+                    fieldValue = preventCsvInjection(fieldValue);
                     fieldValue = wrapFieldValueIfNecessary(fieldValue);
 
                     return fieldValue;
@@ -338,6 +339,26 @@ const Json2Csv = function(options) {
                 return fieldValue.map(trimRecordFieldValue);
             } else if (utils.isString(fieldValue)) {
                 return fieldValue.trim();
+            }
+            return fieldValue;
+        }
+        return fieldValue;
+    }
+
+    /**
+     * Prevent CSV injection on strings if specified by the user's provided options.
+     * Mitigation will be done by ensuring that the first character doesn't being with:
+     * Equals (=), Plus (+), Minus (-), At (@), Tab (0x09), Carriage return (0x0D).
+     * More info: https://owasp.org/www-community/attacks/CSV_Injection
+     * @param fieldValue
+     * @returns {*}
+     */
+     function preventCsvInjection(fieldValue) {
+        if (options.preventCsvInjection) {
+            if (Array.isArray(fieldValue)) {
+                return fieldValue.map(preventCsvInjection);
+            } else if (utils.isString(fieldValue) && !utils.isNumber(fieldValue)) {
+                return fieldValue.replace(/^[=+\-@\t\r]+/g, '');
             }
             return fieldValue;
         }

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -353,7 +353,7 @@ const Json2Csv = function(options) {
      * @param fieldValue
      * @returns {*}
      */
-     function preventCsvInjection(fieldValue) {
+    function preventCsvInjection(fieldValue) {
         if (options.preventCsvInjection) {
             if (Array.isArray(fieldValue)) {
                 return fieldValue.map(preventCsvInjection);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,6 +17,7 @@ module.exports = {
     getNCharacters,
     unwind,
     isInvalid,
+    isNumber,
 
     // underscore replacements:
     isString,
@@ -246,6 +247,15 @@ function unwind(array, field) {
         unwindItem(result, item, field);
     });
     return result;
+}
+
+/**
+ * Checks whether value can be converted to a number
+ * @param value {String}
+ * @returns {boolean}
+ */
+function isNumber(value) {
+    return !isNaN(Number(value));
 }
 
 /*

--- a/test/json2csv.js
+++ b/test/json2csv.js
@@ -761,6 +761,19 @@ function runTests(jsonTestData, csvTestData) {
                 });
             });
 
+            it('should not left trim a combination of csv injection characters if preventCsvInjection is not specified', (done) => {
+                let originalValue = String.fromCharCode(9) + String.fromCharCode(13) + '=+-@Bob';
+                converter.json2csv([{name: originalValue}], (err, csv) => {
+                    if (err) done(err);
+
+                    let expectedCsv = `name\n"${originalValue}"`;
+
+                    csv.should.equal(expectedCsv);
+                    done();
+                }, {
+                });
+            });
+
             // Test case for #184
             it('should handle keys with nested dots when expanding and unwinding arrays', (done) => {
                 converter.json2csv(jsonTestData.nestedDotKeysWithArrayExpandedUnwound, (err, csv) => {

--- a/test/json2csv.js
+++ b/test/json2csv.js
@@ -656,6 +656,111 @@ function runTests(jsonTestData, csvTestData) {
                 });
             });
 
+            // Test cases for https://github.com/mrodrig/json-2-csv/issues/209
+            it('should left trim equals (=) if preventCsvInjection is specified', (done) => {
+                converter.json2csv([{name: '=Bob'}], (err, csv) => {
+                    if (err) done(err);
+
+                    let expectedCsv = 'name\nBob';
+
+                    csv.should.equal(expectedCsv);
+                    done();
+                }, {
+                    preventCsvInjection: true
+                });
+            });
+
+            it('should left trim plus (+) if preventCsvInjection is specified', (done) => {
+                converter.json2csv([{name: '+Bob'}], (err, csv) => {
+                    if (err) done(err);
+
+                    let expectedCsv = 'name\nBob';
+
+                    csv.should.equal(expectedCsv);
+                    done();
+                }, {
+                    preventCsvInjection: true
+                });
+            });
+
+            it('should left trim minus (-) if preventCsvInjection is specified', (done) => {
+                converter.json2csv([{name: '-Bob'}], (err, csv) => {
+                    if (err) done(err);
+
+                    let expectedCsv = 'name\nBob';
+
+                    csv.should.equal(expectedCsv);
+                    done();
+                }, {
+                    preventCsvInjection: true
+                });
+            });
+
+            it('should left trim at (@) if preventCsvInjection is specified', (done) => {
+                converter.json2csv([{name: '@Bob'}], (err, csv) => {
+                    if (err) done(err);
+
+                    let expectedCsv = 'name\nBob';
+
+                    csv.should.equal(expectedCsv);
+                    done();
+                }, {
+                    preventCsvInjection: true
+                });
+            });
+
+            it('should left trim tab (0x09) if preventCsvInjection is specified', (done) => {
+                converter.json2csv([{name: String.fromCharCode(9) + 'Bob'}], (err, csv) => {
+                    if (err) done(err);
+
+                    let expectedCsv = 'name\nBob';
+
+                    csv.should.equal(expectedCsv);
+                    done();
+                }, {
+                    preventCsvInjection: true
+                });
+            });
+
+            it('should left trim carriage return (0x0D) if preventCsvInjection is specified', (done) => {
+                converter.json2csv([{name: String.fromCharCode(13) + 'Bob'}], (err, csv) => {
+                    if (err) done(err);
+
+                    let expectedCsv = 'name\nBob';
+
+                    csv.should.equal(expectedCsv);
+                    done();
+                }, {
+                    preventCsvInjection: true
+                });
+            });
+
+            it('should left trim a combination of csv injection characters if preventCsvInjection is specified', (done) => {
+                converter.json2csv([{name: String.fromCharCode(9) + String.fromCharCode(13) + '=+-@Bob'}], (err, csv) => {
+                    if (err) done(err);
+
+                    let expectedCsv = 'name\nBob';
+
+                    csv.should.equal(expectedCsv);
+                    done();
+                }, {
+                    preventCsvInjection: true
+                });
+            });
+
+            it('should not alter numbers by removing minus (-) even if preventCsvInjection is specified', (done) => {
+                converter.json2csv([{temperature: -10}], (err, csv) => {
+                    if (err) done(err);
+
+                    let expectedCsv = 'temperature\n-10';
+
+                    csv.should.equal(expectedCsv);
+                    done();
+                }, {
+                    preventCsvInjection: true
+                });
+            });
+
             // Test case for #184
             it('should handle keys with nested dots when expanding and unwinding arrays', (done) => {
                 converter.json2csv(jsonTestData.nestedDotKeysWithArrayExpandedUnwound, (err, csv) => {


### PR DESCRIPTION
## Background Information

- Fixes issue(s): #209
- Proposed release version: ` 3.15.0`

I have...
- [x] added at least one test to verify the failure condition is fixed.
- [x] verified the tests are passing.

## Changes

Adds `preventCsvInjection` option to `json2csv()` that left trims the following characters to prevent CSV injection:

* Equals (=)
* Plus (+)
* Minus (-)
* At (@)
* Tab (0x09)
* Carriage return (0x0D)

CSV Injection remediation technique: https://owasp.org/www-community/attacks/CSV_Injection