### PR TITLE
Add parseValue to type definitions

### DIFF
--- a/lib/converter.d.ts
+++ b/lib/converter.d.ts
@@ -109,6 +109,12 @@ export interface IFullOptions extends ISharedOptions {
    * Specify the keys that should be excluded from the output.
    */
   excludeKeys?: string[];
+
+  /**
+   * Specify how values should be converted into CSV format. This function is provided a single field value at a time and must return a `String`.
+   * Note: Using this option may override other options, including `useDateIso8601Format` and `useLocaleFormat`.
+   */
+  parseValue?: (fieldValue: any) => string;
 }
 
 export function json2csv(data: object[],


### PR DESCRIPTION
## Background Information

- Fixes issue(s): #208, https://github.com/mrodrig/json-2-csv/issues/200#issuecomment-940802627
- Proposed release version: `3.15.0`


<!-- Thanks for your pull request! -->