### PR TITLE
Pass default parser to custom parse value function

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Looking for examples? Check out the Wiki: [json-2-csv Wiki](https://github.com/m
       * `[ 'key1', 'key2', ... ]`
       * `[ { field: 'key1', title: 'Key 1' }, { field: 'key2' }, 'key3', ... ]`
     * Key Paths - If you are converting a nested object (ie. {info : {name: 'Mike'}}), then set this to ['info.name']
-  * `parseValue` - Function - Specify how values should be converted into CSV format. This function is provided a single field value at a time and must return a `String`.
+  * `parseValue` - Function - Specify how values should be converted into CSV format. This function is provided a single field value at a time and must return a `String`. The built-in parsing method is provided as the second argument for cases where default parsing is preferred.
     * Default: A built-in method is used to parse out a variety of different value types to well-known formats.
     * Note: Using this option may override other options, including `useDateIso8601Format` and `useLocaleFormat`.
   * `prependHeader` - Boolean - Should the auto-generated header be prepended as the first line in the CSV?

--- a/lib/converter.d.ts
+++ b/lib/converter.d.ts
@@ -114,7 +114,10 @@ export interface IFullOptions extends ISharedOptions {
    * Specify how values should be converted into CSV format. This function is provided a single field value at a time and must return a `String`.
    * Note: Using this option may override other options, including `useDateIso8601Format` and `useLocaleFormat`.
    */
-  parseValue?: (fieldValue: any) => string;
+  parseValue?: (
+    fieldValue: any,
+    defaultParser: (fieldValue: any) => string
+  ) => string;
 }
 
 export function json2csv(data: object[],

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -8,7 +8,7 @@ let path = require('doc-path'),
 const Json2Csv = function(options) {
     const wrapDelimiterCheckRegex = new RegExp(options.delimiter.wrap, 'g'),
         crlfSearchRegex = /\r?\n|\r/,
-        valueParserFn = options.parseValue && typeof options.parseValue === 'function' ? options.parseValue : recordFieldValueToString,
+        customValueParser = options.parseValue && typeof options.parseValue === 'function' ? options.parseValue : null,
         expandingWithoutUnwinding = options.expandArrayObjects && !options.unwindArrays,
         deeksOptions = {
             expandArrayObjects: expandingWithoutUnwinding,
@@ -251,7 +251,7 @@ const Json2Csv = function(options) {
                 // Process the data in this record and return the
                 processedRecordData = recordFieldData.map((fieldValue) => {
                     fieldValue = trimRecordFieldValue(fieldValue);
-                    fieldValue = valueParserFn(fieldValue);
+                    fieldValue = customValueParser ? customValueParser(fieldValue, recordFieldValueToString) : recordFieldValueToString(fieldValue);
                     fieldValue = preventCsvInjection(fieldValue);
                     fieldValue = wrapFieldValueIfNecessary(fieldValue);
 

--- a/test/json2csv.js
+++ b/test/json2csv.js
@@ -647,6 +647,16 @@ function runTests(jsonTestData, csvTestData) {
                 });
             });
 
+            it('should pass the default value parser to custom value parser function when provided', (done) => {
+                converter.json2csv(jsonTestData.trimmedFields, (err, csv) => {
+                    if (err) done(err);
+                    csv.should.equal(csvTestData.trimmedFields);
+                    done();
+                }, {
+                    parseValue: (fieldValue, defaultParser) => defaultParser(fieldValue)
+                });
+            });
+
             it('should wrap boolean values in wrap delimiters, if specified', (done) => {
                 converter.json2csv(jsonTestData.emptyFieldValues, (err, csv) => {
                     if (err) done(err);


### PR DESCRIPTION
## Background Information

- Fixes issue(s): None
- Proposed release version: `3.17`

I have...
- [x] added at least one test to verify the failure condition is fixed.
- [x] verified the tests are passing.

<!-- Thanks for your pull request! -->

Hi @mrodrig,
I'm experimenting with using **json-2-csv** in a project I'm working on and have a use case where I'd like to custom parse some field values but use default parsing for the others. It seems that custom parsing is currently all or nothing, that is, if you provide a `parseValue` function it has to handle all field values. I thought the least disruptive way to enable custom parsing on a value-by-value basis would be to provide access to the built-in parser within the custom parser function so that's what I've done with this PR. The intention is to enable "ejecting" from custom parsing by returning the  result of the default parser. For example,

```js
parseValue: (value, defaultParser) => Array.isArray(value) ? 'They do move in herds.' : defaultParser(value)
```

I considered supplying custom parsers for individual fields as part of the `keys` array (and liked that idea) but felt that this was, again, a less disruptive step in that direction. Happy to hear your feedback/thoughts/suggestions. Thanks for your work on **json-2-csv**.