### PR TITLE
chore: change deprecated string method

### DIFF
--- a/src/csv2json.ts
+++ b/src/csv2json.ts
@@ -311,7 +311,7 @@ export const Csv2Json = function(options: FullCsv2JsonOptions) {
         // If the field starts and ends with a wrap delimiter
         if (firstChar === options.delimiter.wrap && lastChar === options.delimiter.wrap) {
             // Handle the case where the field is just a pair of wrap delimiters 
-            return fieldValue.length <= 2 ? "" : fieldValue.substring(1, lastIndex);
+            return fieldValue.length <= 2 ? '' : fieldValue.substring(1, lastIndex);
         }
         return fieldValue;
     }

--- a/src/csv2json.ts
+++ b/src/csv2json.ts
@@ -310,7 +310,8 @@ export const Csv2Json = function(options: FullCsv2JsonOptions) {
             lastChar = fieldValue[lastIndex];
         // If the field starts and ends with a wrap delimiter
         if (firstChar === options.delimiter.wrap && lastChar === options.delimiter.wrap) {
-            return fieldValue.substring(1, lastIndex - 1);
+            // Handle the case where the field is just a pair of wrap delimiters 
+            return fieldValue.length <= 2 ? "" : fieldValue.substring(1, lastIndex);
         }
         return fieldValue;
     }

--- a/src/csv2json.ts
+++ b/src/csv2json.ts
@@ -114,7 +114,7 @@ export const Csv2Json = function(options: FullCsv2JsonOptions) {
                     splitLine.push('');
                 } else {
                     // Otherwise, there's a valid value, and the start index isn't the current index, grab the whole value
-                    splitLine.push(csv.substr(stateVariables.startIndex));
+                    splitLine.push(csv.substring(stateVariables.startIndex));
                 }
 
                 // Since the last character is a comma, there's still an additional implied field value trailing the comma.
@@ -310,7 +310,7 @@ export const Csv2Json = function(options: FullCsv2JsonOptions) {
             lastChar = fieldValue[lastIndex];
         // If the field starts and ends with a wrap delimiter
         if (firstChar === options.delimiter.wrap && lastChar === options.delimiter.wrap) {
-            return fieldValue.substr(1, lastIndex - 1);
+            return fieldValue.substring(1, lastIndex - 1);
         }
         return fieldValue;
     }


### PR DESCRIPTION
## Background Information

- Fixes issue(s): No
- Proposed release version: ` 5.5.2`

I have...
- [ ] added at least one test to verify the failure condition is fixed.
- [x] verified the tests are passing.

While reading the code, I found deprecated warnings. This is not a breaking change, but rather a precaution against potential errors. A clean project like this should not have trivial and annoying warnings.

<!-- Thanks for your pull request! -->