### PR TITLE
Fix empty array literals being added when an empty array is provided and keys option is provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     },
     "name": "json-2-csv",
     "description": "A JSON to CSV and CSV to JSON converter that natively supports sub-documents and auto-generates the CSV heading.",
-    "version": "5.5.5",
+    "version": "5.5.6",
     "homepage": "https://mrodrig.github.io/json-2-csv",
     "repository": {
         "type": "git",

--- a/src/json2csv.ts
+++ b/src/json2csv.ts
@@ -457,7 +457,7 @@ export const Json2Csv = function(options: FullJson2CsvOptions) {
      */
     function convert(data: object[]) {
         // Single document, not an array
-        if (utils.isObject(data) && !data.length) {
+        if (!Array.isArray(data)) {
             data = [data]; // Convert to an array of the given document
         }
 

--- a/src/json2csv.ts
+++ b/src/json2csv.ts
@@ -35,6 +35,11 @@ export const Json2Csv = function(options: FullJson2CsvOptions) {
      * list of field names.
      */
     function processSchemas(documentSchemas: string[][]) {
+        // If there are no document schemas then there is nothing to diff and no unqiue fields to get
+        if (documentSchemas.length === 0) {
+            return [];
+        }
+
         // If the user wants to check for the same schema (regardless of schema ordering)
         if (options.checkSchemaDifferences) {
             return checkSchemaDifferences(documentSchemas);
@@ -53,8 +58,8 @@ export const Json2Csv = function(options: FullJson2CsvOptions) {
     function checkSchemaDifferences(documentSchemas: string[][]) {
         // have multiple documents - ensure only one schema (regardless of field ordering)
         const firstDocSchema = documentSchemas[0],
-            restOfDocumentSchemas = documentSchemas.slice(1),
-            schemaDifferences = computeNumberOfSchemaDifferences(firstDocSchema, restOfDocumentSchemas);
+        restOfDocumentSchemas = documentSchemas.slice(1),
+        schemaDifferences = computeNumberOfSchemaDifferences(firstDocSchema, restOfDocumentSchemas);
 
         // If there are schema inconsistencies, throw a schema not the same error
         if (schemaDifferences) {

--- a/test/config/testCsvFilesList.ts
+++ b/test/config/testCsvFilesList.ts
@@ -25,6 +25,7 @@ const csvFileConfig = [
     {key: 'trimmedHeader', file: '../data/csv/trimmedHeader.csv'},
     {key: 'excelBOM', file: '../data/csv/excelBOM.csv'},
     {key: 'specifiedKeys', file: '../data/csv/specifiedKeys.csv'},
+    {key: 'specifiedKeysNoData', file: '../data/csv/specifiedKeysNoData.csv'},
     {key: 'extraLine', file: '../data/csv/extraLine.csv'},
     {key: 'noHeader', file: '../data/csv/noHeader.csv'},
     {key: 'sortedHeader', file: '../data/csv/sortedHeader.csv'},

--- a/test/data/csv/specifiedKeysNoData.csv
+++ b/test/data/csv/specifiedKeysNoData.csv
@@ -1,0 +1,1 @@
+arrayOfStrings,object.subField

--- a/test/json2csv.ts
+++ b/test/json2csv.ts
@@ -293,6 +293,13 @@ export function runTests() {
                 assert.equal(csv, csvTestData.specifiedKeys);
             });
 
+            it('should only contain a header when given an empty array and the keys option is provided', () => {
+                const csv = json2csv(jsonTestData.noData, {
+                    keys: ['arrayOfStrings', 'object.subField']
+                });
+                assert.equal(csv, csvTestData.specifiedKeysNoData);
+            });
+
             it('should use the specified empty field value, if provided', () => {
                 jsonTestData.emptyFieldValues[0].number = undefined;
 


### PR DESCRIPTION
## Background Information

- Fixes issue(s): # Empty array literals gets added if you call `json2csv` with an empty array for `data` while also providing `options.keys`.

  given: `converter.json2csv([], { keys: ['header1', 'header2'] });`
 
  Before:
  ```csv
  header1,header2
  [],[]
  ```
  After:
  ```csv
  header1,header
  ```

- Proposed release version: `5.5.6`

I have...
- [x] added at least one test to verify the failure condition is fixed.
- [x] verified the tests are passing.

<!-- Thanks for your pull request! -->