### PR TITLE
fix: comma starting a wrapped value broke the line

### DIFF
--- a/src/csv2json.ts
+++ b/src/csv2json.ts
@@ -190,7 +190,7 @@ export const Csv2Json = function (options: FullCsv2JsonOptions) {
                 stateVariables.insideWrapDelimiter = true;
                 stateVariables.parsingValue = true;
                 stateVariables.startIndex = index;
-            } else if (character === options.delimiter.wrap && charAfter === options.delimiter.field) {
+            } else if (character === options.delimiter.wrap && charAfter === options.delimiter.field && stateVariables.insideWrapDelimiter) {
                 // If we reached a wrap delimiter with a field delimiter after it (ie. *",)
 
                 splitLine.push(csv.substring(stateVariables.startIndex, index + 1));

--- a/test/config/testCsvFilesList.ts
+++ b/test/config/testCsvFilesList.ts
@@ -14,6 +14,7 @@ const csvFileConfig = [
     { key: 'nested', file: '../data/csv/nested.csv' },
     { key: 'nestedMissingField', file: '../data/csv/nestedMissingField.csv' },
     { key: 'comma', file: '../data/csv/comma.csv' },
+    { key: 'commaAfterOpeningWrap', file: '../data/csv/commaAfterOpeningWrap.csv' },
     { key: 'quotes', file: '../data/csv/quotes.csv' },
     { key: 'quotesHeader', file: '../data/csv/quotesHeader.csv' },
     { key: 'quotesAndCommas', file: '../data/csv/quotesAndCommas.csv' },

--- a/test/config/testJsonFilesList.ts
+++ b/test/config/testJsonFilesList.ts
@@ -15,6 +15,7 @@ export default {
     nested: require('../data/json/nested'),
     nestedMissingField: require('../data/json/nestedMissingField'),
     comma: require('../data/json/comma'),
+    commaAfterOpeningWrap: require('../data/json/commaAfterOpeningWrap'),
     quotes: require('../data/json/quotes'),
     quotesHeader: require('../data/json/quotesHeader'),
     quotesAndCommas: require('../data/json/quotesAndCommas'),

--- a/test/csv2json.ts
+++ b/test/csv2json.ts
@@ -71,6 +71,11 @@ export function runTests() {
                 assert.deepEqual(json, jsonTestData.comma);
             });
 
+            it('should convert csv containing a field with a comma after an opening wrap to json', () => {
+                const json = csv2json(csvTestData.commaAfterOpeningWrap);
+                assert.deepEqual(json, jsonTestData.commaAfterOpeningWrap);
+            });
+
             it('should convert csv containing a field with quotes to json', () => {
                 const json = csv2json(csvTestData.quotes);
                 assert.deepEqual(json, jsonTestData.quotes);

--- a/test/data/csv/commaAfterOpeningWrap.csv
+++ b/test/data/csv/commaAfterOpeningWrap.csv
@@ -1,0 +1,3 @@
+username,comment
+mrodrig,",In other words, this is cool!"
+jsmith,"This module is really, really helpful!"

--- a/test/data/json/commaAfterOpeningWrap.json
+++ b/test/data/json/commaAfterOpeningWrap.json
@@ -1,0 +1,10 @@
+[
+  {
+    "username": "mrodrig",
+    "comment": ",In other words, this is cool!"
+  },
+  {
+    "username": "jsmith",
+    "comment": "This module is really, really helpful!"
+  }
+]


### PR DESCRIPTION
## Background Information

If a comma (or any `field` delimiter) is starting a wrapped cell, then the cell is not escaped as a wrapped value and the whole line is broken

I have...
- [x] added at least one test to verify the failure condition is fixed.
- [x] verified the tests are passing.

<!-- Thanks for your pull request! -->